### PR TITLE
Implement unified odds label normalization

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -149,7 +149,7 @@ from utils import (
     get_segment_from_market,
     normalize_lookup_side,  # ✅ This is likely what you actually want
     get_normalized_lookup_side,
-    normalize_to_abbreviation,
+    normalize_label_for_odds,
     convert_full_team_spread_to_odds_key,
     assert_segment_match,
     classify_market_segment,
@@ -1563,13 +1563,12 @@ def log_bets(
 
         if market_key in {"spreads", "h2h"}:
             raw_lookup = convert_full_team_spread_to_odds_key(side_clean)
-            lookup_side = normalize_label(raw_lookup)  # ✅ Use canonical label
-
+            lookup_side = normalize_label_for_odds(raw_lookup, market_key)
         elif market_key == "totals":
-            lookup_side = normalize_to_abbreviation(side_clean)
+            lookup_side = normalize_label_for_odds(side_clean, market_key)
         else:
-            lookup_side = normalize_to_abbreviation(
-                get_normalized_lookup_side(side_clean, market_key)
+            lookup_side = normalize_label_for_odds(
+                get_normalized_lookup_side(side_clean, market_key), market_key
             )
 
         market_entry, best_book, matched_key, segment, price_source = (
@@ -1807,14 +1806,14 @@ def log_derivative_bets(
                 side_clean = standardize_derivative_label(label)
 
                 if market_key in {"spreads", "h2h"}:
-                    lookup_side = normalize_to_abbreviation(
-                        convert_full_team_spread_to_odds_key(side_clean)
+                    lookup_side = normalize_label_for_odds(
+                        convert_full_team_spread_to_odds_key(side_clean), market_key
                     )
                 elif market_key == "totals":
-                    lookup_side = normalize_to_abbreviation(side_clean)
+                    lookup_side = normalize_label_for_odds(side_clean, market_key)
                 else:
-                    lookup_side = normalize_to_abbreviation(
-                        get_normalized_lookup_side(side_clean, market_key)
+                    lookup_side = normalize_label_for_odds(
+                        get_normalized_lookup_side(side_clean, market_key), market_key
                     )
 
                 # Try both "alternate_" and regular market key fallback

--- a/core/odds_normalizer.py
+++ b/core/odds_normalizer.py
@@ -5,7 +5,7 @@ from core.market_pricer import best_price
 from core.consensus_pricer import calculate_consensus_prob
 from utils import (
     normalize_label,
-    build_full_label,
+    normalize_label_for_odds,
     merge_offers_with_alternates,
     TEAM_ABBR,
     TEAM_NAME_TO_ABBR,
@@ -60,13 +60,12 @@ def normalize_market_odds(odds: dict) -> dict:
                 team_desc = outcome.get("description")
                 if label is None or price is None:
                     continue
-                norm_label = normalize_label(label)
                 if "team_totals" in mkey and team_desc:
                     team_abbr = TEAM_NAME_TO_ABBR.get(team_desc.strip(), team_desc.strip())
-                    base = f"{team_abbr} {norm_label}".strip()
+                    base_label = f"{team_abbr} {label}".strip()
                 else:
-                    base = TEAM_NAME_TO_ABBR.get(norm_label, norm_label)
-                full_label = build_full_label(base, mkey, point)
+                    base_label = label
+                full_label = normalize_label_for_odds(base_label, mkey, point)
                 offers.setdefault(mkey, {}).setdefault(book, {})[full_label] = price
 
     offers = merge_offers_with_alternates(offers)

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -2,8 +2,7 @@ from typing import Optional
 
 
 from utils import (
-    normalize_to_abbreviation,
-    get_normalized_lookup_side,
+    normalize_label_for_odds,
     classify_market_segment,
     TEAM_ABBR_TO_NAME,
     TEAM_NAME_TO_ABBR,
@@ -127,9 +126,7 @@ def should_log_bet(
 
     game_id = new_bet["game_id"]
     market = new_bet["market"]
-    side = normalize_to_abbreviation(
-        get_normalized_lookup_side(new_bet["side"], market)
-    )
+    side = normalize_label_for_odds(new_bet["side"], market)
     new_bet["side"] = side  # ensure consistent formatting
     stake = new_bet["full_stake"]
     ev = new_bet["ev_percent"]

--- a/utils.py
+++ b/utils.py
@@ -384,6 +384,66 @@ def build_full_label(normalized_label, market_key, point):
 
     return normalized_label.strip()
 
+
+def normalize_label_for_odds(label: str, market_key: str, point=None) -> str:
+    """Return standardized label for odds lookups.
+
+    Parameters
+    ----------
+    label : str
+        Raw label string (may include team name or Over/Under).
+    market_key : str
+        Canonical market key such as ``spreads`` or ``totals_1st_5_innings``.
+    point : float | None, optional
+        Explicit numeric line value. If ``None``, the value will be extracted
+        from ``label`` when possible.
+
+    Returns
+    -------
+    str
+        Normalized label with consistent spacing, team abbreviations and
+        decimal precision.
+    """
+
+    if label is None:
+        return ""
+
+    base = normalize_label(label)
+
+    if point is None:
+        _, inferred = normalize_line_label(base)
+        point = inferred
+
+    mkey = market_key.lower()
+    if mkey.startswith("spreads") or mkey.startswith("h2h"):
+        base = normalize_to_abbreviation(base)
+
+    return build_full_label(base, mkey, point)
+
+
+def normalize_market_key(market_key: str) -> str:
+    """Return canonical form of ``market_key``.
+
+    Examples
+    --------
+    >>> normalize_market_key("F5 totals")
+    'totals_1st_5_innings'
+    """
+
+    key = market_key.strip().lower().replace(" ", "_")
+    aliases = {
+        "f5_totals": "totals_1st_5_innings",
+        "f5_spreads": "spreads_1st_5_innings",
+        "f5_h2h": "h2h_1st_5_innings",
+        "1st5_totals": "totals_1st_5_innings",
+        "1st5_spreads": "spreads_1st_5_innings",
+        "1st5_h2h": "h2h_1st_5_innings",
+        "totals_f5": "totals_1st_5_innings",
+        "spreads_f5": "spreads_1st_5_innings",
+        "h2h_f5": "h2h_1st_5_innings",
+    }
+    return aliases.get(key, key)
+
 def classify_market_segment(market_key: str) -> str:
     """
     Returns the segment type of a given market key.


### PR DESCRIPTION
## Summary
- add `normalize_label_for_odds` and `normalize_market_key` helpers
- refactor odds fetching and normalization to use the new function
- ensure label normalization in CLI tools and bet logging
- update run distribution utilities to generate canonical labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843359235a4832cb6c8806af9d6f2e4