### PR TITLE
Apply consistent Kelly stake

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -159,13 +159,10 @@ def should_log_bet(
     theme_key = get_theme_key(base_market, theme)
     exposure_key = (game_id, theme_key, segment)
     theme_total = existing_theme_stakes.get(exposure_key, 0.0)
-    # Alternate lines (identified by market prefix or class) should use half of
-    # the normal full_stake amount for the initial entry (⅛ Kelly).
     is_alt_line = market.startswith("alternate_") or new_bet.get("market_class") == "alternate"
 
     if theme_total == 0:
-        stake_amt = stake * 0.5 if is_alt_line else stake
-        new_bet["stake"] = round(stake_amt, 2)
+        new_bet["stake"] = round(stake, 2)
         new_bet["entry_type"] = "first"
         if new_bet["stake"] < 1.0:
             _log_verbose(
@@ -174,7 +171,7 @@ def should_log_bet(
             )
             return None
         _log_verbose(
-            f"✅ should_log_bet: First bet → {side} | {theme_key} [{segment}] | Stake: {stake_amt:.2f}u | EV: {ev:.2f}%",
+            f"✅ should_log_bet: First bet → {side} | {theme_key} [{segment}] | Stake: {stake:.2f}u | EV: {ev:.2f}%",
             verbose,
         )
         return new_bet

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -684,7 +684,8 @@ def build_snapshot_rows(
                 sim_prob, price, market, hours_to_game, consensus_prob
             )
             ev_pct = calculate_ev_from_prob(p_blended, price)
-            stake = kelly_fraction(p_blended, price, fraction=0.25)
+            stake_fraction = 0.125 if price_source == "alternate" else 0.25
+            stake = kelly_fraction(p_blended, price, fraction=stake_fraction)
             market_clean = matched_key.replace("alternate_", "")
             market_class = "alternate" if price_source == "alternate" else "main"
 
@@ -991,7 +992,8 @@ def expand_snapshot_rows_with_kelly(
 
             try:
                 ev = calculate_ev_from_prob(p, odds)
-                stake = kelly_fraction(p, odds, fraction=0.25)
+                fraction = 0.125 if row.get("market_class") == "alternate" else 0.25
+                stake = kelly_fraction(p, odds, fraction=fraction)
             except Exception:
                 continue
 


### PR DESCRIPTION
## Summary
- refactor stake logic to use centralized `kelly_fraction`
- apply 1/8 Kelly for alternate markets
- remove manual halving in `should_log_bet`
- recalc per-book stakes in snapshot expansion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684338a7e970832c921353482b7df78b