### PR TITLE
Fix theme detection for team totals

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -21,6 +21,12 @@ def get_theme(bet: dict) -> str:
     side = bet["side"].strip()
     market = bet["market"].replace("alternate_", "")
 
+    # 🆕 Handle team total bets like "ATL Over 4.5" or "Los Angeles Over 5.0"
+    if "team_totals" in market:
+        _, direction = parse_team_total_side(side)
+        if direction:
+            return direction
+
     if side.startswith("Over"):
         return "Over"
     if side.startswith("Under"):

--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -82,3 +82,19 @@ def test_first_bet_logged_if_odds_improve():
     result = should_log_bet(bet, {}, verbose=False, reference_tracker=reference)
     assert result is not None
     assert result["entry_type"] == "first"
+
+
+def test_team_total_classified_as_over():
+    bet = {"side": "ATL Over 4.5", "market": "team_totals"}
+    theme = get_theme(bet)
+    assert theme == "Over"
+    theme_key = get_theme_key(bet["market"], theme)
+    assert theme_key == "Over_total"
+
+
+def test_team_total_classified_as_under():
+    bet = {"side": "NYY Under 3.5", "market": "team_totals"}
+    theme = get_theme(bet)
+    assert theme == "Under"
+    theme_key = get_theme_key(bet["market"], theme)
+    assert theme_key == "Under_total"


### PR DESCRIPTION
## Summary
- classify team totals using parse_team_total_side
- test Over/Under classification for team totals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684341eda600832c9ab83e4f7b027cdd