### PR TITLE
Improve snapshot failure logging

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -268,7 +268,7 @@ def run_unified_snapshot_and_dispatch(odds_path: str):
     today_str, tomorrow_str = get_date_strings()
     date_arg = f"{today_str},{tomorrow_str}"
 
-    subprocess.run(
+    exit_code = run_subprocess(
         [
             PYTHON,
             "core/unified_snapshot_generator.py",
@@ -276,11 +276,15 @@ def run_unified_snapshot_and_dispatch(odds_path: str):
             odds_path,
             "--date",
             date_arg,
-        ],
-        cwd=ROOT_DIR,
-        env=os.environ,
-        check=True,
+        ]
     )
+
+    if exit_code != 0:
+        logger.error(
+            "❌ Unified snapshot generation failed (code %s); skipping dispatch.",
+            exit_code,
+        )
+        return
 
     for script in [
         "dispatch_live_snapshot.py",


### PR DESCRIPTION
## Summary
- use `run_subprocess` in `run_unified_snapshot_and_dispatch`
- bail out of dispatch if snapshot generation fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434e054c48832c8cab066bb2723e4c