### PR TITLE
Include hours_to_game in snapshot rows

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -714,6 +714,7 @@ def build_snapshot_rows(
                 "best_book": best_book,
                 "_raw_sportsbook": sportsbook_odds,
                 "date_simulated": datetime.now().isoformat(),
+                "hours_to_game": round(hours_to_game, 2),
             }
             row["segment_label"] = get_segment_label(matched_key, normalized_side)
             theme = get_theme({"side": normalized_side, "market": market_clean})


### PR DESCRIPTION
## Summary
- propagate game start timing into snapshot rows for movement detection
- record hours_to_game when building rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438cbfd0cc832cb31588c2c93ed5a0