### PR TITLE
Standardize hours_to_game calculation

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -155,6 +155,7 @@ from utils import (
     canonical_game_id,
     now_eastern,
 )
+from core.utils import compute_hours_to_game
 
 
 # === Staking Logic Refactor ===
@@ -1442,11 +1443,7 @@ def log_bets(
     start_dt = odds_start_times.get(game_id)
     hours_to_game = 8.0
     if start_dt:
-        from pytz import timezone
-
-        eastern = timezone("US/Eastern")
-        now = datetime.now(eastern)
-        hours_to_game = (start_dt - now).total_seconds() / 3600
+        hours_to_game = compute_hours_to_game(start_dt)
 
     if hours_to_game < 0:
         print(
@@ -1666,11 +1663,7 @@ def log_derivative_bets(
     start_dt = odds_start_times.get(game_id)
     hours_to_game = 8.0
     if start_dt:
-        from pytz import timezone
-
-        eastern = timezone("US/Eastern")
-        now = datetime.now(eastern)
-        hours_to_game = (start_dt - now).total_seconds() / 3600
+        hours_to_game = compute_hours_to_game(start_dt)
 
     if hours_to_game < 0:
         print(

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -26,7 +26,10 @@ from utils import (
     get_market_entry_with_alternate_fallback,
     normalize_label_for_odds,
     get_segment_label,
+    to_eastern,
+    now_eastern,
 )
+from core.utils import compute_hours_to_game
 from core.should_log_bet import get_theme, get_theme_key
 from core.market_pricer import (
     to_american_odds,
@@ -620,11 +623,9 @@ def build_snapshot_rows(
         if start_str:
             try:
                 dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
-                dt_et = dt.astimezone(ZoneInfo("America/New_York"))
-                now_et = datetime.now(ZoneInfo("America/New_York"))
-                hours_to_game = (dt_et - now_et).total_seconds() / 3600
+                hours_to_game = compute_hours_to_game(dt)
                 print(
-                    f"🕓 DEBUG: {game_id} — start={dt_et.isoformat()} | now={now_et.isoformat()} | delta={hours_to_game:.2f}h"
+                    f"🕓 DEBUG: {game_id} — start={to_eastern(dt).isoformat()} | now={now_eastern().isoformat()} | delta={hours_to_game:.2f}h"
                 )
             except Exception:
                 pass

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,18 @@
+"""Utility helpers for core modules."""
+
+from datetime import datetime
+from typing import Optional
+
+from utils import to_eastern, now_eastern
+
+
+def compute_hours_to_game(game_start: datetime, now: Optional[datetime] = None) -> float:
+    """Return hours until ``game_start`` relative to ``now``.
+
+    Both ``game_start`` and ``now`` may be naive or timezone-aware. They are
+    normalized to US/Eastern before the difference is calculated.  If ``now``
+    is ``None`` the current Eastern time is used.
+    """
+    start_et = to_eastern(game_start)
+    now_et = to_eastern(now or now_eastern())
+    return (start_et - now_et).total_seconds() / 3600


### PR DESCRIPTION
## Summary
- add `compute_hours_to_game` in `core/utils`
- reuse helper in `log_betting_evals` and `snapshot_core`
- use Eastern time consistently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438f01a4e0832c993dd2a7a3f2f158