### PR TITLE
Centralize probability blending

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -129,10 +129,10 @@ from core.market_pricer import (
     decimal_odds,
     to_american_odds,
     kelly_fraction,
-    blend_prob,
     calculate_ev_from_prob,
     extract_best_book,
 )
+from core.scaling_utils import blend_prob
 from core.odds_fetcher import fetch_market_odds_from_api, save_market_odds_to_file
 from utils import (
     TEAM_ABBR,
@@ -675,10 +675,6 @@ def expand_snapshot_rows_with_kelly(
 
 
 
-def logistic_decay(t_hours, t_switch=8, slope=1.5):
-    return 1 / (1 + math.exp((t_switch - t_hours) / slope))
-
-
 def market_prob_increase_threshold(hours_to_game: float, market_type: str = "") -> float:
     """Return required market_prob delta for logging based on time to game.
 
@@ -699,39 +695,12 @@ def market_prob_increase_threshold(hours_to_game: float, market_type: str = "") 
         return floor + (decay * (hours_to_game - 6) / 42)
 
 
-def base_model_weight_for_market(market):
-    if "1st" in market:
-        return 0.9  # prioritize derivatives (1st innings) first
-    elif (
-        market.startswith("h2h")
-        or (market.startswith("spreads") and "_" not in market)
-        or (market.startswith("totals") and "_" not in market)
-    ):
-        return 0.6  # mainlines (h2h, spreads, totals without "_")
-    else:
-        return 0.75  # fallback for anything else
-
-
 def should_include_in_summary(row):
     """
     Return True if the row qualifies to appear in summary notifications.
     Currently defined as EV ≥ 5.0%.
     """
     return row.get("ev_percent", 0) >= 5.0
-
-
-def blend_prob(p_model, market_odds, market_type, hours_to_game, p_market=None):
-    # Use provided consensus_prob if available, otherwise derive from odds
-    if p_market is None:
-        p_market = implied_prob(market_odds)
-
-    base_weight = base_model_weight_for_market(market_type)
-    w_time = logistic_decay(hours_to_game, t_switch=8, slope=1.5)
-    w_model = min(base_weight * w_time, 1.0)
-    w_market = 1 - w_model
-
-    p_blended = w_model * p_model + w_market * p_market
-    return p_blended, w_model, p_model, p_market
 
 
 def get_theme(row):

--- a/core/market_pricer.py
+++ b/core/market_pricer.py
@@ -156,16 +156,6 @@ def compute_moneyline(home_scores, away_scores):
     }
 
 
-def logistic_decay(t_hours, t_switch=8, slope=1.5):
-    return 1 / (1 + math.exp((t_switch - t_hours) / slope))
-
-def base_model_weight_for_market(market):
-    if "1st" in market:
-        return 0.9  # prioritize derivatives (1st innings) first
-    elif market.startswith("h2h") or (market.startswith("spreads") and "_" not in market) or (market.startswith("totals") and "_" not in market):
-        return 0.6  # mainlines (h2h, spreads, totals without "_")
-    else:
-        return 0.75  # fallback for anything else
 
 def get_market_price(market_dict, market, side):
     """
@@ -205,20 +195,6 @@ def get_market_price(market_dict, market, side):
 
 
 
-def blend_prob(p_model, market_odds, market_type, hours_to_game, p_market=None):
-    """
-    Blend model simulation probability with market consensus probability.
-    """
-    if p_market is None:
-        p_market = implied_prob(market_odds)
-
-    base_weight = base_model_weight_for_market(market_type)
-    w_time = logistic_decay(hours_to_game, t_switch=8, slope=1.5)
-    w_model = min(base_weight * w_time, 1.0)
-    w_market = 1 - w_model
-
-    p_blended = w_model * p_model + w_market * p_market
-    return p_blended, w_model, p_model, p_market
 
 
 # === CLI Summary Formatter ===

--- a/core/scaling_utils.py
+++ b/core/scaling_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 
 
 def scale_distribution(raw_vals, target_mean=None, target_sd=None):
@@ -12,3 +13,38 @@ def scale_distribution(raw_vals, target_mean=None, target_sd=None):
     if target_mean is not None:
         scaled = scaled + (target_mean - raw_mean)
     return scaled.tolist()
+
+
+def logistic_decay(t_hours, t_switch=8, slope=1.5):
+    """Return a weight that decays with time until game start."""
+    return 1 / (1 + math.exp((t_switch - t_hours) / slope))
+
+
+def base_model_weight_for_market(market):
+    """Return base model weight depending on market type."""
+    if "1st" in market:
+        return 0.9  # prioritize derivatives (1st innings)
+    elif (
+        market.startswith("h2h")
+        or (market.startswith("spreads") and "_" not in market)
+        or (market.startswith("totals") and "_" not in market)
+    ):
+        return 0.6  # mainlines (h2h, spreads, totals without "_")
+    else:
+        return 0.75  # fallback for anything else
+
+
+def blend_prob(p_model, market_odds, market_type, hours_to_game, p_market=None):
+    """Blend model and market probabilities with time-based weighting."""
+    from core.market_pricer import implied_prob
+
+    if p_market is None:
+        p_market = implied_prob(market_odds)
+
+    base_weight = base_model_weight_for_market(market_type)
+    w_time = logistic_decay(hours_to_game, t_switch=8, slope=1.5)
+    w_model = min(base_weight * w_time, 1.0)
+    w_market = 1 - w_model
+
+    p_blended = w_model * p_model + w_market * p_market
+    return p_blended, w_model, p_model, p_market

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -34,11 +34,11 @@ from core.should_log_bet import get_theme, get_theme_key
 from core.market_pricer import (
     to_american_odds,
     kelly_fraction,
-    blend_prob,
     calculate_ev_from_prob,
     decimal_odds,
     extract_best_book,
 )
+from core.scaling_utils import blend_prob
 from core.consensus_pricer import calculate_consensus_prob
 from core.market_movement_tracker import track_and_update_market_movement
 from core.market_eval_tracker import load_tracker, save_tracker


### PR DESCRIPTION
## Summary
- move blend logic to `core/scaling_utils.py`
- import the shared functions in CLI and snapshot code
- drop the old duplication from `market_pricer.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684390531a98832c9a11f0319c262c8d