### PR TITLE
Add quiet hours guard to logging

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1154,6 +1154,11 @@ def write_to_csv(
         Mapping used to track current theme exposure in-memory. Updated on
         successful writes.
     """
+    from utils import logging_allowed_now
+
+    if not logging_allowed_now():
+        print("🕒 Logging disabled during quiet hours (10pm-8am ET). Skipping CSV write.")
+        return None
     key = (row["game_id"], row["market"], row["side"])
     tracker_key = (
         f"{row['game_id']}:{row['market']}:{row['side']}"

--- a/tests/test_logging_window.py
+++ b/tests/test_logging_window.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from datetime import datetime
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import logging_allowed_now, EASTERN_TZ
+
+
+def test_logging_allowed_daytime():
+    dt = datetime(2024, 1, 1, 12, 0, tzinfo=EASTERN_TZ)
+    assert logging_allowed_now(dt)
+
+
+def test_logging_blocked_at_night():
+    late = datetime(2024, 1, 1, 22, 30, tzinfo=EASTERN_TZ)
+    early = datetime(2024, 1, 1, 7, 59, tzinfo=EASTERN_TZ)
+    assert not logging_allowed_now(late)
+    assert not logging_allowed_now(early)

--- a/utils.py
+++ b/utils.py
@@ -26,6 +26,18 @@ def to_eastern(dt: datetime) -> datetime:
     return dt.astimezone(EASTERN_TZ)
 
 
+def logging_allowed_now(now: datetime | None = None) -> bool:
+    """Return True if logging should be allowed at the given time.
+
+    Logging to CSV and theme exposure files is disabled between
+    10 PM and 8 AM Eastern time.  If ``now`` is not provided the
+    current Eastern time is used.
+    """
+    dt = to_eastern(now) if now else now_eastern()
+    hour = dt.hour
+    return 8 <= hour < 22
+
+
 def safe_load_json(path: str):
     """Load JSON from ``path`` with helpful diagnostics on failure."""
     try:


### PR DESCRIPTION
## Summary
- prevent writing bets to `market_evals.csv` between 10 PM and 8 AM ET
- expose `logging_allowed_now` helper in `utils`
- add unit tests for the new quiet-hours behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439fc65380832c839cfc642c0f1790