### PR TITLE
Implement strict 10‑minute gating for closing odds monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Windows users can start just the monitor via `launch_closing_odds_monitor.bat`.
 These tools help measure closing line value (CLV) for your logged bets.
 
 * **closing_odds_monitor.py** – runs continuously and checks the Odds API for
-  games starting within 15 minutes. When closing odds are found it saves a
+  games starting within 10 minutes. When closing odds are found it saves a
   snapshot under `data/closing_odds/` and posts a Discord alert summarizing the
   expected value of any logged bets for that game. Set `DISCORD_ALERT_WEBHOOK_URL`
   in your `.env` to enable alerts. You can also define

--- a/cli/closing_odds_monitor.py
+++ b/cli/closing_odds_monitor.py
@@ -365,6 +365,16 @@ def monitor_loop(poll_interval=600, target_date=None, force_game_id=None):
                 if debug_mode:
                     logger.debug("DEBUG: %s | time_to_game=%.2fs", gid, time_to_game)
 
+                # Reject games outside the closing odds window
+                if time_to_game > 600 or time_to_game < 0:
+                    if debug_mode:
+                        logger.debug(
+                            "⏩ Skipping %s - outside 10 minute window (%.2fs)",
+                            gid,
+                            time_to_game,
+                        )
+                    continue
+
                 if gid not in tracked_games:
                     continue
 
@@ -390,11 +400,11 @@ def monitor_loop(poll_interval=600, target_date=None, force_game_id=None):
                         continue
 
 
-                # Only capture closing odds within ~15 minutes of first pitch
+                # Only capture closing odds within ~10 minutes of first pitch
                 # ``commence_time`` from the API is in UTC, so ``game_time`` is
                 # already converted to Eastern above. ``time_to_game`` is
                 # therefore an Eastern-based delta in seconds.
-                if 0 <= time_to_game <= 900:
+                if 0 <= time_to_game <= 600:
                     logger.info("📡 Fetching consensus odds for %s...", gid)
 
                     consensus_odds = None


### PR DESCRIPTION
## Summary
- enforce 10 minute window for fetching closing odds
- skip events outside the window
- document the new timing window in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b12be198832cacad9eb8d992d36b