### PR TITLE
Add debug for unmatched market lookup

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -851,7 +851,13 @@ def get_market_entry_with_alternate_fallback(market_odds, market_key, lookup_sid
                 source_type,
             )
 
+    available_map = {
+        key: sorted(market_odds.get(key, {}).keys())
+        for key in search_keys
+        if isinstance(market_odds.get(key, {}), dict)
+    }
     log(f"❌ No match for '{normalized}' in: {search_keys}")
+    log(f"   ↳ Available keys: {available_map}")
     return None, "unknown", "❌", "❌", "❌"
 
 


### PR DESCRIPTION
## Summary
- log available market keys when `get_market_entry_with_alternate_fallback` can't match a side

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844186c3300832cae50487bfb706e59