### PR TITLE
Tag bet skips for EV/stake rules

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -144,6 +144,11 @@ def should_log_bet(
             print(
                 f"⛔ should_log_bet: Rejected due to EV/stake threshold → EV: {ev:.2f}%, Stake: {stake:.2f}u"
             )
+        new_bet["entry_type"] = "none"
+        if ev < min_ev * 100:
+            new_bet["skip_reason"] = "low_ev"
+        elif stake < min_stake:
+            new_bet["skip_reason"] = "low_stake"
         return None
 
     prior_entry = None
@@ -201,6 +206,8 @@ def should_log_bet(
                 f"⛔ Skipping bet — scaled stake {new_bet['stake']}u is below 1.0u minimum",
                 verbose,
             )
+            new_bet["entry_type"] = "none"
+            new_bet["skip_reason"] = "low_stake"
             return None
         _log_verbose(
             f"✅ should_log_bet: First bet → {side} | {theme_key} [{segment}] | Stake: {stake:.2f}u | EV: {ev:.2f}%",
@@ -217,6 +224,8 @@ def should_log_bet(
                 f"⛔ Skipping top-up — delta stake {new_bet['stake']}u is below 0.5u minimum",
                 verbose,
             )
+            new_bet["entry_type"] = "none"
+            new_bet["skip_reason"] = "low_stake"
             return None
         _log_verbose(
             f"🔼 should_log_bet: Top-up accepted → {side} | {theme_key} [{segment}] | Δ {delta:.2f}u",
@@ -225,5 +234,6 @@ def should_log_bet(
         return new_bet
 
     new_bet["entry_type"] = "none"
+    new_bet["skip_reason"] = "low_stake"
     _log_verbose("⛔ Rejected — top-up delta too small (< 0.5u)", verbose)
     return None

--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -46,6 +46,7 @@ def test_top_up_rejected_for_small_delta():
     result = should_log_bet(bet, existing_theme_stakes, verbose=False, eval_tracker=tracker)
     assert result is None
     assert bet["entry_type"] == "none"
+    assert bet["skip_reason"] == "low_stake"
 
 
 def test_first_bet_rejected_if_odds_worse():
@@ -98,3 +99,33 @@ def test_team_total_classified_as_under():
     assert theme == "Under"
     theme_key = get_theme_key(bet["market"], theme)
     assert theme_key == "Under_total"
+
+
+def test_rejected_for_low_ev():
+    bet = {
+        "game_id": "gid",
+        "market": "totals",
+        "side": "Over 8.5",
+        "full_stake": 1.2,
+        "ev_percent": 3.0,
+    }
+
+    result = should_log_bet(bet, {}, verbose=False, min_ev=0.05)
+    assert result is None
+    assert bet["entry_type"] == "none"
+    assert bet["skip_reason"] == "low_ev"
+
+
+def test_rejected_for_low_stake():
+    bet = {
+        "game_id": "gid",
+        "market": "totals",
+        "side": "Over 8.5",
+        "full_stake": 0.5,
+        "ev_percent": 6.0,
+    }
+
+    result = should_log_bet(bet, {}, verbose=False, min_stake=1.0)
+    assert result is None
+    assert bet["entry_type"] == "none"
+    assert bet["skip_reason"] == "low_stake"


### PR DESCRIPTION
## Summary
- mark bets rejected in `should_log_bet` as `entry_type: none`
- record why a bet was skipped via `skip_reason`
- test for low EV and stake skip tagging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456b322740832cb340af36d3f34a1d