### PR TITLE
Fix reference-odds rejection for first-time bets

### DIFF
--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -49,7 +49,7 @@ def test_top_up_rejected_for_small_delta():
     assert bet["skip_reason"] == "low_stake"
 
 
-def test_first_bet_rejected_if_odds_worse():
+def test_first_bet_logged_even_if_odds_worse():
     bet = {
         "game_id": "gid",
         "market": "h2h",
@@ -63,6 +63,25 @@ def test_first_bet_rejected_if_odds_worse():
     reference = {tracker_key: {"market_odds": 110, "ev_percent": 7.0}}
 
     result = should_log_bet(bet, {}, verbose=False, reference_tracker=reference)
+    assert result is not None
+    assert result["entry_type"] == "first"
+
+
+def test_top_up_rejected_if_odds_worse():
+    bet = {
+        "game_id": "gid",
+        "market": "h2h",
+        "side": "TeamA",
+        "full_stake": 2.0,
+        "ev_percent": 6.0,
+        "market_odds": 105,
+    }
+    exposure_key = _exposure_key(bet)
+    existing_theme_stakes = {exposure_key: 1.0}
+    tracker_key = f"{bet['game_id']}:{bet['market']}:TeamA"
+    reference = {tracker_key: {"market_odds": 110, "ev_percent": 7.0}}
+
+    result = should_log_bet(bet, existing_theme_stakes, verbose=False, reference_tracker=reference)
     assert result is None
     assert bet["entry_type"] == "none"
 


### PR DESCRIPTION
## Summary
- ensure `should_log_bet` only rejects on worse reference odds if we've already
  staked on that market
- adjust unit tests and add coverage for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456cb227bc832cbc412c6355e5dd09