### PR TITLE
Fix stake rounding before top-up checks

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -217,9 +217,11 @@ def should_log_bet(
         )
         return new_bet
 
-    delta = stake - theme_total
+    # Round the delta once to avoid floating point drift across the pipeline
+    delta_raw = stake - theme_total
+    delta = round(delta_raw, 2)
     if delta >= 0.5:
-        new_bet["stake"] = round(delta, 2)
+        new_bet["stake"] = delta
         new_bet["entry_type"] = "top-up"
         if new_bet["stake"] < 0.5:
             _log_verbose(

--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -49,6 +49,25 @@ def test_top_up_rejected_for_small_delta():
     assert bet["skip_reason"] == "low_stake"
 
 
+def test_top_up_delta_rounded_before_threshold():
+    bet = {
+        "game_id": "gid",
+        "market": "totals",
+        "side": "Over 8.5",
+        "full_stake": 1.7,
+        "ev_percent": 6.0,
+    }
+    exposure_key = _exposure_key(bet)
+    existing = 0.4 * 3  # 1.2000000000000002 introduces floating point imprecision
+    existing_theme_stakes = {exposure_key: existing}
+    tracker = {f"{bet['game_id']}:{bet['market']}:Over 8.5": {"stake": existing}}
+
+    result = should_log_bet(bet, existing_theme_stakes, verbose=False, eval_tracker=tracker)
+    assert result is not None
+    assert result["entry_type"] == "top-up"
+    assert result["stake"] == 0.5
+
+
 def test_first_bet_logged_even_if_odds_worse():
     bet = {
         "game_id": "gid",


### PR DESCRIPTION
## Summary
- round stake delta once in `should_log_bet` and compare after rounding
- add regression test for floating-point rounding near 0.5u threshold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456edbd0fc832c87a0ab276a25c1e2