### PR TITLE
Fix missing argparse import

### DIFF
--- a/core/dispatch_sim_only_snapshot.py
+++ b/core/dispatch_sim_only_snapshot.py
@@ -6,6 +6,7 @@ import sys
 import json
 import io
 from typing import List
+import argparse
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
## Summary
- resolve NameError in `dispatch_sim_only_snapshot` by importing argparse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846118cc928832c9dea5f8738451769