### PR TITLE
Allow top-up bets to bypass market probability gate

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1309,23 +1309,24 @@ def write_to_csv(
     new_prob = row.get("market_prob")
     hours_to_game = row.get("hours_to_game", 8)
 
-    if prior_prob is None or new_prob is None:
-        print("⛔ No prior market probability — building baseline and skipping log.")
-        track_and_update_market_movement(
-            row,
-            MARKET_EVAL_TRACKER,
-            MARKET_EVAL_TRACKER_BEFORE_UPDATE,
-        )
-        row["skip_reason"] = "market_not_moved"
-        return None
-    elif new_prob <= prior_prob:
-        print("⛔ Market probability did not improve — skipping.")
-        row["skip_reason"] = "market_not_moved"
-        return None
-    else:
-        delta = new_prob - prior_prob
-        threshold = market_prob_increase_threshold(hours_to_game, row.get("market", ""))
-        if delta < threshold:
+    threshold = market_prob_increase_threshold(hours_to_game, row.get("market", ""))
+
+    if row.get("entry_type") == "first":
+        if prior_prob is None or new_prob is None:
+            print("⛔ No prior market probability — building baseline and skipping log.")
+            track_and_update_market_movement(
+                row,
+                MARKET_EVAL_TRACKER,
+                MARKET_EVAL_TRACKER_BEFORE_UPDATE,
+            )
+            row["skip_reason"] = "market_not_moved"
+            return None
+        elif new_prob <= prior_prob:
+            print("⛔ Market probability did not improve — skipping.")
+            row["skip_reason"] = "market_not_moved"
+            return None
+        elif (new_prob - prior_prob) < threshold:
+            delta = new_prob - prior_prob
             print(
                 f"⛔ Market % increase too small ({delta:.4f} < {threshold:.4f}) — skipping."
             )

--- a/tests/test_skip_logging_reasons.py
+++ b/tests/test_skip_logging_reasons.py
@@ -48,6 +48,18 @@ def test_skip_reason_market_not_moved(monkeypatch, tmp_path):
     assert row["skip_reason"] == "market_not_moved"
 
 
+def test_top_up_skips_movement_check(monkeypatch, tmp_path):
+    row = _base_row()
+    row["entry_type"] = "top-up"
+    row["market_prob"] = 0.55
+    row["_prior_snapshot"] = {"market_prob": 0.6}
+    row["sportsbook"] = "B1"
+    monkeypatch.setattr("utils.logging_allowed_now", lambda now=None: True)
+    result = write_to_csv(row, tmp_path / "t.csv", {}, {}, {}, dry_run=False, force_log=False)
+    assert result is not None
+    assert "skip_reason" not in row
+
+
 def test_send_discord_notification_no_webhook(monkeypatch):
     row = _base_row()
     monkeypatch.setattr("cli.log_betting_evals.get_discord_webhook_for_market", lambda m: "")


### PR DESCRIPTION
## Summary
- only enforce market probability movement requirements for first entries
- keep top-ups exempt from the gating logic
- add regression test for this bypass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684635a84018832c82c2984aeb0672bc