### PR TITLE
Implement game ID disambiguation helpers

### DIFF
--- a/cli/closing_odds_monitor.py
+++ b/cli/closing_odds_monitor.py
@@ -359,7 +359,8 @@ def monitor_loop(poll_interval=600, target_date=None, force_game_id=None):
 
                 away_abbr = TEAM_ABBR.get(away_team_full, away_team_full.split()[-1])
                 home_abbr = TEAM_ABBR.get(home_team_full, home_team_full.split()[-1])
-                gid = f"{game_date}-{away_abbr}@{home_abbr}"
+                raw_id = disambiguate_game_id(game_date, away_abbr, home_abbr, game_time)
+                gid = canonical_game_id(raw_id)
 
                 time_to_game = (game_time - now_est).total_seconds()
                 if debug_mode:

--- a/core/odds_normalizer.py
+++ b/core/odds_normalizer.py
@@ -44,7 +44,8 @@ def normalize_market_odds(odds: dict) -> dict:
             date_str = start_ts.strftime("%Y-%m-%d")
             away_abbr = TEAM_ABBR.get(away_team, away_team)
             home_abbr = TEAM_ABBR.get(home_team, home_team)
-            game_id = canonical_game_id(f"{date_str}-{away_abbr}@{home_abbr}")
+            raw_id = disambiguate_game_id(date_str, away_abbr, home_abbr, start_ts)
+            game_id = canonical_game_id(raw_id)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- add `disambiguate_game_id` and `parse_game_id` helpers
- keep time suffix when normalizing with `canonical_game_id`
- generate time-stamped IDs when extracting events
- include timestamped IDs in odds normalization, closing odds monitor, and probable pitchers utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e5e51c3c832c90bca627b70fd386