### PR TITLE
Update closing odds scripts for disambiguated IDs

### DIFF
--- a/cli/closing_odds_fetcher.py
+++ b/cli/closing_odds_fetcher.py
@@ -9,7 +9,7 @@ from core.odds_fetcher import (
     american_to_prob,
 )
 from core.market_pricer import to_american_odds
-from utils import normalize_line_label, safe_load_json
+from utils import normalize_line_label, safe_load_json, canonical_game_id
 
 load_dotenv()
 from core.logger import get_logger
@@ -22,7 +22,8 @@ def load_game_ids_from_csv(csv_path):
     with open(csv_path, "r") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            game_ids.add(row["game_id"])
+            gid = canonical_game_id(row["game_id"])
+            game_ids.add(gid)
     return sorted(game_ids)
 
 

--- a/cli/closing_odds_monitor.py
+++ b/cli/closing_odds_monitor.py
@@ -17,6 +17,8 @@ from utils import (
     safe_load_json,
     normalize_to_abbreviation,
     normalize_line_label,
+    canonical_game_id,
+    extract_game_id_from_event,
 )
 from dotenv import load_dotenv
 
@@ -359,7 +361,12 @@ def monitor_loop(poll_interval=600, target_date=None, force_game_id=None):
 
                 away_abbr = TEAM_ABBR.get(away_team_full, away_team_full.split()[-1])
                 home_abbr = TEAM_ABBR.get(home_team_full, home_team_full.split()[-1])
-                raw_id = disambiguate_game_id(game_date, away_abbr, home_abbr, game_time)
+
+                raw_id = extract_game_id_from_event(
+                    away_team_full,
+                    home_team_full,
+                    game_time,
+                )
                 gid = canonical_game_id(raw_id)
 
                 time_to_game = (game_time - now_est).total_seconds()

--- a/cli/update_clv_column.py
+++ b/cli/update_clv_column.py
@@ -16,6 +16,7 @@ from utils import (
     safe_load_json,
     normalize_line_label,
     normalize_to_abbreviation,
+    canonical_game_id,
 )
 from core.odds_fetcher import american_to_prob  # ✅ Corrected path
 
@@ -82,7 +83,7 @@ def update_clv(csv_path, odds_json_path, target_date):
 
     updated_rows = []
     for row in rows:
-        gid = row.get("game_id")
+        gid = canonical_game_id(row.get("game_id", ""))
         row_date = gid[:10] if gid else ""
 
         # ⛔ Skip if not from the target date


### PR DESCRIPTION
## Summary
- monitor closing odds using `extract_game_id_from_event` so time suffixes are preserved
- normalize game IDs when fetching historical closing odds
- canonicalize IDs when updating CLV columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fb8d63dc832cbd465a93f4067d97