### PR TITLE
Format snapshot time as 12-hour with AM/PM

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -970,6 +970,9 @@ def send_discord_notification(row, skipped_bets=None):
         away_team = TEAM_ABBR_TO_NAME.get(parts["away"], parts["away"])
         home_team = TEAM_ABBR_TO_NAME.get(parts["home"], parts["home"])
         event_label = f"{away_team} @ {home_team}"
+        game_time = row.get("Time")
+        if isinstance(game_time, str) and game_time.strip():
+            event_label += f" ({game_time} ET)"
     except Exception:
         event_label = game_id
 


### PR DESCRIPTION
## Summary
- parse and store start time in US/Eastern for each snapshot row
- display snapshot time using 12‑hour format
- include game time in Discord notifications when available

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68470174c024832caca01dd780696273