### PR TITLE
Add odds filter to should_log_bet

### DIFF
--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -203,3 +203,35 @@ def test_rejected_for_low_stake():
     assert result is None
     assert bet["entry_type"] == "none"
     assert bet["skip_reason"] == "low_stake"
+
+
+def test_rejected_for_odds_too_high():
+    bet = {
+        "game_id": "gid",
+        "market": "h2h",
+        "side": "TeamA",
+        "full_stake": 1.2,
+        "ev_percent": 6.0,
+        "market_odds": 205,
+    }
+
+    result = should_log_bet(bet, {}, verbose=False)
+    assert result is None
+    assert bet["entry_type"] == "none"
+    assert bet["skip_reason"] == "bad_odds"
+
+
+def test_rejected_for_odds_too_negative():
+    bet = {
+        "game_id": "gid",
+        "market": "h2h",
+        "side": "TeamA",
+        "full_stake": 1.2,
+        "ev_percent": 6.0,
+        "market_odds": -155,
+    }
+
+    result = should_log_bet(bet, {}, verbose=False)
+    assert result is None
+    assert bet["entry_type"] == "none"
+    assert bet["skip_reason"] == "bad_odds"


### PR DESCRIPTION
## Summary
- add a new odds range filter to `should_log_bet`
- reject high (+200) or low (-150) odds when logging bets
- test the new odds filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847054f15a0832ca0096200cd9c1abc