### PR TITLE
Add Date & Time columns to logs

### DIFF
--- a/cli/replay_skipped_bets.py
+++ b/cli/replay_skipped_bets.py
@@ -6,6 +6,9 @@ import os
 from utils import canonical_game_id
 
 FIELDNAMES = [
+    "Date",
+    "Time",
+    "Matchup",
     "game_id",
     "market",
     "market_class",


### PR DESCRIPTION
## Summary
- parse game IDs for human-friendly Date/Time/Matchup
- write these fields to `market_evals.csv`
- keep the same display logic for snapshots
- update replay script for new CSV layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684710372dd4832cb5d97d80c1f6cfac