### PR TITLE
Filter FV drop dispatch odds

### DIFF
--- a/tests/test_market_prob_filter.py
+++ b/tests/test_market_prob_filter.py
@@ -7,6 +7,9 @@ import pandas as pd
 from core.dispatch_fv_drop_snapshot import (
     is_market_prob_increasing,
     filter_by_books,
+    parse_american_odds,
+    filter_by_odds,
+    filter_main_lines,
 )
 
 
@@ -24,3 +27,22 @@ def test_filter_by_books():
     assert subset["Book"].tolist() == ["a", "c"]
     subset_empty = filter_by_books(df, [])
     assert subset_empty.equals(df)
+
+
+def test_parse_american_odds():
+    assert parse_american_odds("+120") == 120.0
+    assert parse_american_odds("-110") == -110.0
+    assert parse_american_odds("N/A") is None
+
+
+def test_filter_by_odds_and_main_lines():
+    df = pd.DataFrame(
+        {
+            "Book": ["a", "a", "a"],
+            "Odds": ["+150", "-200", "-130"],
+            "Market Class": ["Main", "Alt", "Main"],
+        }
+    )
+    subset = filter_main_lines(df)
+    subset = filter_by_odds(subset, -150, 200)
+    assert subset["Odds"].tolist() == ["+150", "-130"]


### PR DESCRIPTION
## Summary
- filter FV drop dispatch to main lines only and clamp odds between `-150` and `+200`
- test odds and mainline filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684714a81cd8832cad058f45caa7640c