### PR TITLE
Include game time in expanded snapshot rows

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -627,6 +627,7 @@ def expand_snapshot_rows_with_kelly(
             "league": bet.get("league", "MLB"),
             "Date": bet.get("Date", ""),
             "Matchup": bet.get("Matchup", bet.get("game_id", "")[-7:]),
+            "Time": bet.get("Time", ""),
             "side": bet.get("side", ""),
             "market": bet.get("market", ""),
             "sim_prob": bet.get("sim_prob", 0),


### PR DESCRIPTION
## Summary
- keep the `Time` field when expanding snapshot rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684721656ba8832c9b89b11feb554655