### PR TITLE
Add Start Time (ISO) column to log rows

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1403,6 +1403,7 @@ def write_to_csv(
     fieldnames = [
         "Date",
         "Time",
+        "Start Time (ISO)",
         "Matchup",
         "game_id",
         "market",
@@ -1664,6 +1665,9 @@ def log_bets(
             "date_simulated": date_sim,
             "result": "",
         }
+
+        # Preserve the raw start timestamp for filtering/debugging
+        row["Start Time (ISO)"] = market_odds.get("start_time", "")
 
         if isinstance(book_prices, dict):
             row["_raw_sportsbook"] = book_prices.copy()
@@ -1981,6 +1985,9 @@ def log_derivative_bets(
                     "date_simulated": date_sim,
                     "result": "",
                 }
+
+                # Preserve the raw start timestamp for filtering/debugging
+                row["Start Time (ISO)"] = market_odds.get("start_time", "")
 
                 if isinstance(book_prices, dict):
                     row["_raw_sportsbook"] = book_prices.copy()


### PR DESCRIPTION
## Summary
- capture raw game start timestamp when logging bets
- include new **Start Time (ISO)** column in market_evals.csv header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472424ee80832cb498ed57d500a33e