### PR TITLE
Fix replay skipped bets missing Date/Time fields

### DIFF
--- a/cli/replay_skipped_bets.py
+++ b/cli/replay_skipped_bets.py
@@ -2,8 +2,9 @@ import argparse
 import csv
 import json
 import os
+from datetime import datetime
 
-from utils import canonical_game_id
+from utils import canonical_game_id, parse_game_id
 
 FIELDNAMES = [
     "Date",
@@ -97,6 +98,16 @@ def main():
         if key in existing:
             continue
         bet["game_id"] = gid
+
+        parsed = parse_game_id(gid)
+        bet["Date"] = parsed.get("date", "")
+        bet["Matchup"] = f"{parsed['away']} @ {parsed['home']}"
+        time_raw = parsed.get("time", "")
+        if time_raw.startswith("T"):
+            bet["Time"] = datetime.strptime(time_raw[1:], "%H%M").strftime("%-I:%M %p")
+        else:
+            bet["Time"] = ""
+
         new_rows.append(bet)
         existing.add(key)
 


### PR DESCRIPTION
## Summary
- parse the game ID when replaying skipped bets
- populate Date, Time, and Matchup columns when rebuilding missing bets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847272d47a0832c82c09255049362a5