### PR TITLE
Add time-suffixed game IDs to sim filenames

### DIFF
--- a/cli/full_slate_runner.py
+++ b/cli/full_slate_runner.py
@@ -104,7 +104,11 @@ def main():
 
     # Fetch all games for the specified window
     matchups = fetch_probable_pitchers(days_ahead=days_ahead)
-    game_ids = sorted(gid for gid in matchups if gid.startswith(date_str))
+    game_ids = sorted(
+        canonical_game_id(gid)
+        for gid in matchups
+        if gid.startswith(date_str)
+    )
 
     if not game_ids:
         logger.error("❌ No games found for %s", date_str)

--- a/cli/run_distribution_simulator.py
+++ b/cli/run_distribution_simulator.py
@@ -771,7 +771,7 @@ def simulate_distribution(game_id, line, debug=False, no_weather=False, edge_thr
 
     # === Output JSON ===
     date_tag = "-".join(game_id.split("-")[:3])
-    target_path = os.path.join("backtest", "sims", date_tag, f"{game_id}.json")
+    target_path = export_json or os.path.join("backtest", "sims", date_tag, f"{game_id}.json")
 
     # 📊 Segment-level summaries
     def inning_summary(inning_cap, label, benchmark=None):


### PR DESCRIPTION
## Summary
- store simulation outputs using canonical IDs with time suffix
- ensure canonical IDs are gathered when running the full slate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684738482ea4832c8fe8d216f0c73848