### PR TITLE
Ensure full game_id used for odds matching

### DIFF
--- a/tests/test_unified_snapshot_generator.py
+++ b/tests/test_unified_snapshot_generator.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import core.unified_snapshot_generator as usg
+
+
+def test_build_snapshot_uses_full_game_id(monkeypatch):
+    gid = "2025-06-09-ATL@MIL-T1941"
+    sims = {gid: {}}
+    monkeypatch.setattr(usg, "load_simulations", lambda *_: sims)
+
+    captured = {}
+
+    def fake_build_snapshot_rows(sim_data, odds, min_ev=0.01):
+        captured["sim_keys"] = list(sim_data.keys())
+        captured["odds_keys"] = list(odds.keys())
+        return []
+
+    monkeypatch.setattr(usg, "build_snapshot_rows", fake_build_snapshot_rows)
+    monkeypatch.setattr(usg, "expand_snapshot_rows_with_kelly", lambda rows: rows)
+
+    odds_data = {gid: {"h2h": {}}}
+    rows = usg.build_snapshot_for_date("2025-06-09", odds_data)
+
+    assert captured["sim_keys"] == [gid]
+    assert captured["odds_keys"] == [gid]
+    assert rows == []


### PR DESCRIPTION
## Summary
- add regression test to verify `build_snapshot_for_date()` passes full `game_id` keys when slicing market odds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684739e3b2f0832ca795d7b21fefd1f6