### PR TITLE
Ensure fetchers use suffix-aware IDs

### DIFF
--- a/cli/daily_odds_fetcher.py
+++ b/cli/daily_odds_fetcher.py
@@ -39,7 +39,10 @@ def run_daily_odds_pipeline():
         print(f"⚠️ Sim folder does not exist: {sim_folder}")
         return
 
-    game_ids = [f.replace(".json", "") for f in os.listdir(sim_folder) if f.endswith(".json")]
+    from pathlib import Path
+
+    sim_dir = Path(sim_folder)
+    game_ids = [f.stem for f in sim_dir.glob("*.json") if "-T" in f.stem]
     print(f"\n📅 Running daily odds fetch for {len(game_ids)} games on {today_tag}\n")
 
     odds_data = fetch_market_odds_from_api(game_ids)

--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -2714,11 +2714,10 @@ if __name__ == "__main__":
             sys.exit(1)
         odds_file = args.odds_path
     else:
-        games = [
-            f.replace(".json", "")
-            for f in os.listdir(args.eval_folder)
-            if f.endswith(".json")
-        ]
+        from pathlib import Path
+
+        sim_dir = Path(args.eval_folder)
+        games = [f.stem for f in sim_dir.glob("*.json") if "-T" in f.stem]
         print(f"📡 Fetching market odds for {len(games)} games on {date_tag}...")
         odds = fetch_market_odds_from_api(games)
         timestamp_tag = now_eastern().strftime("market_odds_%Y%m%dT%H%M")


### PR DESCRIPTION
## Summary
- use Path.glob to read sim files and extract suffixed IDs in daily odds fetcher
- use same logic when fetching odds in log_betting_evals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473be17aa0832c8e6333f1f78cc636