### PR TITLE
Fix game_id parsing for simulation markets

### DIFF
--- a/cli/run_distribution_simulator.py
+++ b/cli/run_distribution_simulator.py
@@ -93,9 +93,9 @@ def extract_universal_markets(game_id, full_game_market, derivative_segments, ru
             "source": "simulator"
         }
 
-    away, home = game_id.rsplit("-", 1)[-1].split("@")
-    away = away.upper()
-    home = home.upper()
+    parts = parse_game_id(game_id)
+    away = parts["away"].upper()
+    home = parts["home"].upper()
     entries = []
 
     # === Moneyline (H2H)


### PR DESCRIPTION
## Summary
- use `parse_game_id()` when extracting matchup info in `run_distribution_simulator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476152bfa8832cb7de234c0f2c4921