### PR TITLE
Add helper for team extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,5 +163,6 @@ YYYY-MM-DD-AWAY@HOME-T%H%M
 #### Helpers:
 - `disambiguate_game_id(date, away, home, start_time_et)` → returns full game_id.
 - `parse_game_id(game_id)` → returns dict with `date`, `away`, `home`, `time`.
+- `get_teams_from_game_id(game_id)` → returns `(away, home)` tuple.
 
 All modules should use these helpers for consistency.

--- a/cli/run_distribution_simulator.py
+++ b/cli/run_distribution_simulator.py
@@ -39,6 +39,7 @@ from assets.env_builder import (
 from utils import (
     canonical_game_id,
     parse_game_id,
+    get_teams_from_game_id,
     TEAM_ABBR_TO_NAME,
     TEAM_NAME_TO_ABBR,
     normalize_label_for_odds,
@@ -93,9 +94,9 @@ def extract_universal_markets(game_id, full_game_market, derivative_segments, ru
             "source": "simulator"
         }
 
-    parts = parse_game_id(game_id)
-    away = parts["away"].upper()
-    home = parts["home"].upper()
+    away, home = get_teams_from_game_id(game_id)
+    away = away.upper()
+    home = home.upper()
     entries = []
 
     # === Moneyline (H2H)

--- a/core/consensus_pricer.py
+++ b/core/consensus_pricer.py
@@ -5,7 +5,7 @@ from utils import (
     normalize_label,
     TEAM_ABBR_TO_NAME,
     TEAM_NAME_TO_ABBR,
-    parse_game_id,
+    get_teams_from_game_id,
 )
 
 _DEVIG_WARNING_LOGGED = set()
@@ -265,9 +265,7 @@ def get_paired_label(label, market_key, game_id, point=None):
 
     if market_key.startswith("h2h"):
         try:
-            parts = parse_game_id(game_id)
-            away_abbr = parts["away"]
-            home_abbr = parts["home"]
+            away_abbr, home_abbr = get_teams_from_game_id(game_id)
             away_name = TEAM_ABBR_TO_NAME.get(away_abbr, away_abbr)
             home_name = TEAM_ABBR_TO_NAME.get(home_abbr, home_abbr)
 
@@ -295,9 +293,7 @@ def get_paired_label(label, market_key, game_id, point=None):
 
 
 def get_opponent_abbr_by_game_id(team_name, game_id):
-    parts = parse_game_id(game_id)
-    away = parts["away"]
-    home = parts["home"]
+    away, home = get_teams_from_game_id(game_id)
     team_abbr = TEAM_NAME_TO_ABBR.get(team_name, team_name)
     return home if team_abbr.upper() == away.upper() else away
 

--- a/core/game_asset_builder.py
+++ b/core/game_asset_builder.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from assets.probable_pitchers import fetch_probable_pitchers
 from assets.lineup_scraper_selenium import fetch_lineups_selenium
 from assets.stats_loader import load_batter_stats, load_pitcher_stats, normalize_name
-from utils import parse_game_id
+from utils import get_teams_from_game_id
 from assets.bullpen_utils import build_bullpen_for_team
 from core.project_hr_pa import project_hr_pa
 import numpy as np
@@ -91,8 +91,7 @@ def build_game_assets(game_id, batter_stats, pitcher_stats, patch_hrfb=False):
         # 🔍 Helpful keys print for tracing
         print(f"✅ Lineup data loaded: keys = {list(lineup_data.keys())}")
 
-        parsed_id = parse_game_id(game_id)
-        away_abbr_raw, home_abbr_raw = parsed_id["away"], parsed_id["home"]
+        away_abbr_raw, home_abbr_raw = get_teams_from_game_id(game_id)
         away_abbr = TEAM_ABBR_FIXES.get(away_abbr_raw.strip().upper(), away_abbr_raw.strip().upper())
         home_abbr = TEAM_ABBR_FIXES.get(home_abbr_raw.strip().upper(), home_abbr_raw.strip().upper())
 

--- a/core/normalize_odds.py
+++ b/core/normalize_odds.py
@@ -1,5 +1,9 @@
 from core.market_pricer import implied_prob, to_american_odds, best_price
-from utils import normalize_label, merge_offers_with_alternates, parse_game_id
+from utils import (
+    normalize_label,
+    merge_offers_with_alternates,
+    get_teams_from_game_id,
+)
 import numpy as np
 
 
@@ -12,9 +16,7 @@ def normalize_odds(game_id: str, offers: dict) -> dict:
     ]
 
     def get_opponent_abbr(team_abbr, game_id):
-        parts = parse_game_id(game_id)
-        away = parts["away"]
-        home = parts["home"]
+        away, home = get_teams_from_game_id(game_id)
         return home if team_abbr.upper() == away.upper() else away
 
     print(f"\n🔍 Normalizing odds for: {game_id}")

--- a/tests/test_get_teams_from_game_id.py
+++ b/tests/test_get_teams_from_game_id.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import utils
+
+
+def test_get_teams_from_valid_game_id():
+    away, home = utils.get_teams_from_game_id("2025-05-05-CHW@KC-T1305-DH1")
+    assert away == "CHW"
+    assert home == "KC"
+
+
+def test_get_teams_from_invalid_game_id():
+    away, home = utils.get_teams_from_game_id("2025-05-05")
+    assert away == ""
+    assert home == ""

--- a/utils.py
+++ b/utils.py
@@ -895,6 +895,15 @@ def parse_game_id(game_id: str) -> dict:
         return {"date": game_id, "away": "", "home": "", "time": ""}
 
 
+def get_teams_from_game_id(game_id: str) -> tuple[str, str]:
+    """Return ``(away, home)`` team codes extracted from ``game_id``."""
+    try:
+        parts = parse_game_id(game_id)
+        return parts.get("away", ""), parts.get("home", "")
+    except Exception:
+        return "", ""
+
+
 def extract_game_id_from_event(away_team, home_team, start_time):
     """Construct a time-stamped game ID using US/Eastern time.
 


### PR DESCRIPTION
## Summary
- add `get_teams_from_game_id` utility for quick team lookup
- document the helper in README
- use new helper in odds normalization, consensus pricing, lineup asset builder, and run distribution simulator
- test helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476ab28274832ca775f02181af5fb4