### PR TITLE
Defensive check in extract_start_times

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -2175,6 +2175,12 @@ def run_batch_logging(
         from dateutil import parser
         from pytz import timezone
 
+        if not isinstance(odds_data, dict):
+            print(
+                "⚠️ extract_start_times: odds_data is None or invalid, returning empty dict."
+            )
+            return {}
+
         eastern = timezone("US/Eastern")
         start_times = {}
         for game_id, game in odds_data.items():
@@ -2182,7 +2188,9 @@ def run_batch_logging(
                 continue
             if "start_time" in game:
                 try:
-                    start_times[game_id] = parser.parse(game["start_time"]).astimezone(eastern)
+                    start_times[game_id] = parser.parse(game["start_time"]).astimezone(
+                        eastern
+                    )
                 except Exception:
                     pass
         return start_times


### PR DESCRIPTION
## Summary
- prevent `extract_start_times` from crashing when odds data is missing or invalid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68478e374f28832c97928c817053a16a