### PR TITLE
Improve odds handling in auto loop

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -206,6 +206,12 @@ def fetch_and_cache_odds_snapshot() -> str | None:
         "\n📡 [%s] Fetching market odds for today and tomorrow...", now_eastern()
     )
     odds = fetch_all_market_odds(lookahead_days=2)
+    if not odds or not isinstance(odds, dict) or len(odds) == 0:
+        logger.error(
+            "❌ Fetched odds snapshot is empty or invalid — skipping loop cycle."
+        )
+        return None
+    logger.debug("📊 Fetched game_ids: %s", list(odds.keys()))
     timestamp = now_eastern().strftime("%Y%m%dT%H%M")
     tag = f"market_odds_{timestamp}"
     odds_path = save_market_odds_to_file(odds, tag)

--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -2160,12 +2160,17 @@ def run_batch_logging(
         if all_market_odds is None:
             print(f"❌ Failed to load odds file {market_odds}")
             return
+        if not all_market_odds or not isinstance(all_market_odds, dict):
+            print(f"❌ Odds file {market_odds} is empty or malformed — skipping logging.")
+            return
     else:
         all_market_odds = market_odds
 
     fallback_odds = {}
     if fallback_odds_path:
         fallback_odds = safe_load_json(fallback_odds_path) or {}
+        if not isinstance(fallback_odds, dict):
+            fallback_odds = {}
         print(
             f"📂 Loaded fallback odds from {fallback_odds_path} ({len(fallback_odds)} games)"
         )


### PR DESCRIPTION
## Summary
- guard against empty or invalid odds in auto loop
- validate odds data before logging
- sanitize fallback odds load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68478fff9e18832ca7f2819a0353fa81