### PR TITLE
Add guard for missing market odds

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -2152,6 +2152,10 @@ def run_batch_logging(
 
     load_dotenv()
 
+    if market_odds is None:
+        print("❌ No odds data provided. Use --odds-path or pass market_odds as a dict.")
+        return
+
     DISCORD_SUMMARY_WEBHOOK_URL = os.getenv("DISCORD_SUMMARY_WEBHOOK_URL")
     summary_candidates = []
 


### PR DESCRIPTION
## Summary
- prevent `get()` on `None` when logging betting evaluations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684793676c04832ca1957d8ced33a0a8