### PR TITLE
Centralize game ID logic

### DIFF
--- a/core/game_id_utils.py
+++ b/core/game_id_utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Helpers for constructing and matching ``game_id`` strings."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import List, Optional
+
+def _get_eastern_tz():
+    from utils import EASTERN_TZ  # imported lazily to avoid circular deps
+    return EASTERN_TZ
+
+__all__ = ["build_game_id", "normalize_game_id", "fuzzy_match_game_id"]
+
+
+def build_game_id(away: str, home: str, start_time_utc: datetime) -> str:
+    """Return a time-aware ``game_id`` using ET-local date and time."""
+    if start_time_utc.tzinfo is None:
+        start_time_utc = start_time_utc.replace(tzinfo=ZoneInfo("UTC"))
+    start_et = start_time_utc.astimezone(_get_eastern_tz())
+    date_str = start_et.strftime("%Y-%m-%d")
+    suffix = start_et.strftime("T%H%M")
+    return f"{date_str}-{away}@{home}-{suffix}"
+
+
+def normalize_game_id(game_id: str) -> str:
+    """Strip ``-T`` suffix from ``game_id`` for base matchup comparison."""
+    return game_id.split("-T")[0] if "-T" in game_id else game_id
+
+
+def _suffix_minutes(gid: str) -> Optional[int]:
+    if "-T" not in gid:
+        return None
+    raw = gid.split("-T", 1)[1].split("-", 1)[0]
+    try:
+        dt = datetime.strptime(raw, "%H%M")
+    except Exception:
+        return None
+    return dt.hour * 60 + dt.minute
+
+
+def fuzzy_match_game_id(target: str, candidates: List[str], window: int = 5) -> Optional[str]:
+    """Return candidate within ``window`` minutes of ``target`` if found."""
+    base = normalize_game_id(target)
+    target_min = _suffix_minutes(target)
+    best: Optional[str] = None
+    best_delta: Optional[int] = None
+    for cand in candidates:
+        if normalize_game_id(cand) != base:
+            continue
+        cand_min = _suffix_minutes(cand)
+        if target_min is None or cand_min is None:
+            return cand
+        delta = abs(cand_min - target_min)
+        if delta <= window and (best_delta is None or delta < best_delta):
+            best = cand
+            best_delta = delta
+    return best
+

--- a/tests/test_game_id_utils.py
+++ b/tests/test_game_id_utils.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.game_id_utils import build_game_id, normalize_game_id, fuzzy_match_game_id
+
+
+def test_build_game_id_converts_to_eastern():
+    start = datetime(2025, 6, 9, 17, 5, tzinfo=ZoneInfo("UTC"))
+    gid = build_game_id("MIL", "CIN", start)
+    assert gid == "2025-06-09-MIL@CIN-T1305"
+
+
+def test_normalize_game_id_strips_suffix():
+    assert normalize_game_id("2025-06-09-MIL@CIN-T1305") == "2025-06-09-MIL@CIN"
+    assert normalize_game_id("2025-06-09-MIL@CIN") == "2025-06-09-MIL@CIN"
+
+
+def test_fuzzy_match_game_id_window():
+    target = "2025-06-09-MIL@CIN-T1307"
+    cands = ["2025-06-09-MIL@CIN-T1305", "2025-06-09-MIL@CIN-T1500"]
+    assert fuzzy_match_game_id(target, cands, window=5) == "2025-06-09-MIL@CIN-T1305"
+    assert fuzzy_match_game_id(target, cands, window=1) is None

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import json
 import traceback
 
+from core.game_id_utils import build_game_id
+
 UNMATCHED_MARKET_LOOKUPS = defaultdict(list)
 
 # Timezone helpers
@@ -917,11 +919,12 @@ def extract_game_id_from_event(away_team, home_team, start_time):
         else:
             dt = start_time
 
-        start_et = to_eastern(dt)
-        local_date = start_et.strftime("%Y-%m-%d")
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+
         away_abbr = TEAM_ABBR.get(away_team, away_team)
         home_abbr = TEAM_ABBR.get(home_team, home_team)
-        return disambiguate_game_id(local_date, away_abbr, home_abbr, start_et)
+        return build_game_id(away_abbr, home_abbr, dt)
     except Exception as e:
         from core.logger import get_logger
         get_logger(__name__).debug("[DEBUG] extract_game_id_from_event error: %s", e)


### PR DESCRIPTION
## Summary
- add `core/game_id_utils` with utilities for building/normalizing game IDs and fuzzy matching
- refactor `extract_game_id_from_event` to use the new helper
- test new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479704078c832c84c64ce01a85f254