### PR TITLE
Fix crash when odds_start_times is None

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1528,6 +1528,8 @@ def log_bets(
 
     game_id = canonical_game_id(game_id)
 
+    odds_start_times = odds_start_times or {}
+
     date_sim = datetime.now().strftime("%Y-%m-%d %I:%M %p")
     candidates = []
 
@@ -1758,6 +1760,8 @@ def log_derivative_bets(
 
     date_sim = datetime.now().strftime("%Y-%m-%d %I:%M %p")
     candidates = []
+
+    odds_start_times = odds_start_times or {}
 
     start_dt = odds_start_times.get(game_id)
     hours_to_game = 8.0


### PR DESCRIPTION
## Summary
- guard log functions against `None` odds_start_times

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847989f5840832ca508fcb6aec5a5f7