### PR TITLE
Improve fallback odds lookup

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -202,6 +202,7 @@ from utils import (
     normalize_label,
     get_segment_label,
     canonical_game_id,
+    lookup_fallback_odds,
     now_eastern,
 )
 from core.time_utils import compute_hours_to_game
@@ -2310,7 +2311,7 @@ def run_batch_logging(
 
         mkt = all_market_odds.get(game_id)
         if (not mkt) and fallback_odds:
-            mkt = fallback_odds.get(game_id)
+            mkt = lookup_fallback_odds(game_id, fallback_odds)
             if mkt:
                 print(f"🔄 Using fallback odds for {raw_game_id}")
 

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -17,7 +17,7 @@ from datetime import timedelta
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "cli")))
 
-from utils import now_eastern, safe_load_json
+from utils import now_eastern, safe_load_json, lookup_fallback_odds
 from core.logger import get_logger
 from core.odds_fetcher import fetch_market_odds_from_api
 from core.snapshot_core import (
@@ -99,7 +99,7 @@ def build_snapshot_rows(sim_data: dict, odds_json: dict, min_ev: float = 0.01):
     if VERBOSE or DEBUG:
         for game_id in sim_data.keys():
             print(f"\U0001F50D Evaluating {game_id}")
-            if odds_json.get(game_id):
+            if lookup_fallback_odds(game_id, odds_json):
                 print(f"\u2705 Matched odds for {game_id}")
             else:
                 print(f"\u274C No odds found for {game_id}")
@@ -122,7 +122,7 @@ def build_snapshot_for_date(
     if odds_data is None:
         odds = fetch_market_odds_from_api(list(sims.keys()))
     else:
-        odds = {gid: odds_data.get(gid) for gid in sims.keys()}
+        odds = {gid: lookup_fallback_odds(gid, odds_data) for gid in sims.keys()}
 
     for gid in sims.keys():
         if gid not in odds or odds.get(gid) is None:

--- a/tests/test_game_id_utils.py
+++ b/tests/test_game_id_utils.py
@@ -5,7 +5,12 @@ from zoneinfo import ZoneInfo
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.game_id_utils import build_game_id, normalize_game_id, fuzzy_match_game_id
+from core.game_id_utils import (
+    build_game_id,
+    normalize_game_id,
+    fuzzy_match_game_id,
+)
+from utils import lookup_fallback_odds
 
 
 def test_build_game_id_converts_to_eastern():
@@ -24,3 +29,20 @@ def test_fuzzy_match_game_id_window():
     cands = ["2025-06-09-MIL@CIN-T1305", "2025-06-09-MIL@CIN-T1500"]
     assert fuzzy_match_game_id(target, cands, window=5) == "2025-06-09-MIL@CIN-T1305"
     assert fuzzy_match_game_id(target, cands, window=1) is None
+
+
+def test_lookup_fallback_odds_matching():
+    fb = {
+        "2025-06-09-MIL@CIN-T1305": {"odds": 100},
+        "2025-06-09-MIL@CIN-T1500": {"odds": 200},
+    }
+    res = lookup_fallback_odds("2025-06-09-MIL@CIN-T1307", fb)
+    assert res == {"odds": 100}
+    res_none = lookup_fallback_odds("2025-06-09-ATL@MIA-T1305", fb)
+    assert res_none is None
+
+
+def test_lookup_fallback_odds_base_match():
+    fb = {"2025-06-09-MIL@CIN": {"odds": 300}}
+    res = lookup_fallback_odds("2025-06-09-MIL@CIN-T1400", fb)
+    assert res == {"odds": 300}


### PR DESCRIPTION
## Summary
- add `lookup_fallback_odds` helper that fuzzy matches by game id
- use helper in bet logging and snapshot generation
- test fallback odds helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479a97ee54832cbf949df6a946a32d