### PR TITLE
Fix market movement tracker persistence

### DIFF
--- a/core/market_eval_tracker.py
+++ b/core/market_eval_tracker.py
@@ -3,7 +3,19 @@ import json
 import time
 from typing import Dict
 
+from utils import canonical_game_id, parse_game_id
+
 TRACKER_PATH = os.path.join('backtest', 'market_eval_tracker.json')
+
+
+def build_tracker_key(game_id: str, market: str, side: str) -> str:
+    """Return a normalized key for the tracker."""
+    parts = parse_game_id(game_id)
+    if parts.get("away") and parts.get("home"):
+        gid = canonical_game_id(game_id)
+    else:
+        gid = game_id
+    return f"{gid}:{str(market).strip()}:{str(side).strip()}"
 
 
 def load_tracker(path: str = TRACKER_PATH) -> Dict[str, dict]:

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -44,7 +44,7 @@ from core.market_pricer import (
 from core.scaling_utils import blend_prob
 from core.consensus_pricer import calculate_consensus_prob
 from core.market_movement_tracker import track_and_update_market_movement
-from core.market_eval_tracker import load_tracker, save_tracker
+from core.market_eval_tracker import load_tracker, save_tracker, build_tracker_key
 import copy
 
 # Load tracker once for snapshot utilities and keep a frozen copy for comparisons
@@ -851,7 +851,7 @@ def build_snapshot_rows(
             theme = get_theme({"side": normalized_side, "market": market_clean})
             row["theme_key"] = get_theme_key(market_clean, theme)
             row.setdefault("entry_type", "first")
-            tracker_key = f"{game_id}:{market_clean.strip()}:{side.strip()}"
+            tracker_key = build_tracker_key(game_id, market_clean, side)
             prior_row = MARKET_EVAL_TRACKER.get(tracker_key) or MARKET_EVAL_TRACKER_BEFORE_UPDATE.get(tracker_key)
 
             row["_tracker_entry"] = prior_row
@@ -1106,9 +1106,10 @@ def expand_snapshot_rows_with_kelly(
 
     for row in rows:
         per_book = row.get("_raw_sportsbook") or {}
-        tracker_key = (
-            f"{row.get('game_id')}:{str(row.get('market', '')).strip()}:"
-            f"{str(row.get('side', '')).strip()}"
+        tracker_key = build_tracker_key(
+            row.get("game_id"),
+            row.get("market", ""),
+            row.get("side", ""),
         )
         prior_row = (
             MARKET_EVAL_TRACKER_BEFORE_UPDATE.get(tracker_key)
@@ -1187,9 +1188,10 @@ def expand_snapshot_rows_with_kelly(
                     "full_stake": stake,
                 }
             )
-            tracker_key = (
-                f"{expanded_row['game_id']}:{expanded_row['market'].strip()}:"
-                f"{expanded_row['side'].strip()}"
+            tracker_key = build_tracker_key(
+                expanded_row["game_id"],
+                expanded_row["market"],
+                expanded_row["side"],
             )
             prior_row = (
                 MARKET_EVAL_TRACKER_BEFORE_UPDATE.get(tracker_key)

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -23,8 +23,10 @@ from core.odds_fetcher import fetch_market_odds_from_api
 from core.snapshot_core import (
     load_simulations,
     build_snapshot_rows as _core_build_snapshot_rows,
+    MARKET_EVAL_TRACKER,
 )
 from core.snapshot_core import expand_snapshot_rows_with_kelly
+from core.market_eval_tracker import save_tracker
 
 logger = get_logger(__name__)
 
@@ -241,6 +243,9 @@ def main() -> None:
             for row in rows_for_date:
                 row["snapshot_for_date"] = date_str
             all_rows.extend(rows_for_date)
+
+        save_tracker(MARKET_EVAL_TRACKER)
+        print(f"\U0001F4BE Saved market_eval_tracker with {len(MARKET_EVAL_TRACKER)} entries.")
     
         timestamp = now_eastern().strftime("%Y%m%dT%H%M")
         out_dir = "backtest"


### PR DESCRIPTION
## Summary
- normalize tracker keys with canonical game id when possible
- log field changes in market movement tracker
- ensure tracker is persisted from unified snapshot generation
- use tracker key helper in snapshot generation and logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684810251bc8832c8183fb9d2757e4cc