### PR TITLE
Update movement comparison logic

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -249,13 +249,13 @@ def _style_dataframe(df: pd.DataFrame) -> pd.io.formats.style.Styler:
             colors = []
             moves = df.get(move_col)
             for mv in moves if moves is not None else []:
-                if mv == "better":
+                if mv in ("better", "up"):
                     colors.append(
                         "background-color: #f8d7da"
                         if invert
                         else "background-color: #d4edda"
                     )
-                elif mv == "worse":
+                elif mv in ("worse", "down"):
                     colors.append(
                         "background-color: #d4edda"
                         if invert

--- a/tests/test_display_delta_threshold.py
+++ b/tests/test_display_delta_threshold.py
@@ -24,6 +24,6 @@ def test_display_delta_respects_threshold(monkeypatch):
     movement = mmt.detect_market_movement(entry, prior)
     entry.update(movement)
     sc.annotate_display_deltas(entry, prior)
-    assert entry['mkt_movement'] == 'better'
+    assert entry['mkt_movement'] == 'up'
     assert entry['mkt_prob_display'].startswith('46.0%')
     assert '→' in entry['mkt_prob_display']

--- a/tests/test_market_prob_increase_threshold.py
+++ b/tests/test_market_prob_increase_threshold.py
@@ -42,7 +42,7 @@ def test_detect_movement_derivative_vs_mainline():
         "market": "h2h",
         "hours_to_game": 50,
     }
-    assert mmt.detect_market_movement(derivative, prior)["mkt_movement"] == "better"
+    assert mmt.detect_market_movement(derivative, prior)["mkt_movement"] == "up"
     assert mmt.detect_market_movement(mainline, prior)["mkt_movement"] == "same"
 
 
@@ -59,7 +59,7 @@ def test_detect_movement_hours_to_game():
         "hours_to_game": 6,
     }
     assert mmt.detect_market_movement(far, prior)["mkt_movement"] == "same"
-    assert mmt.detect_market_movement(close, prior)["mkt_movement"] == "better"
+    assert mmt.detect_market_movement(close, prior)["mkt_movement"] == "up"
 
 
 def test_detect_movement_missing_hours(monkeypatch):
@@ -74,4 +74,4 @@ def test_detect_movement_missing_hours(monkeypatch):
         lbe, "market_prob_increase_threshold", lambda h, m: 0.02
     )
 
-    assert mmt.detect_market_movement(row, prior)["mkt_movement"] == "better"
+    assert mmt.detect_market_movement(row, prior)["mkt_movement"] == "up"


### PR DESCRIPTION
## Summary
- adjust logic for comparing market movement in `market_movement_tracker`
- skip tracker update when no changes detected
- interpret `up` and `down` movement in snapshot formatting
- update tests for new movement labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483a290e8c832c9626f41f855f602a