### PR TITLE
Fix logging of market probability

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1495,6 +1495,8 @@ def write_to_csv(
     )
     print(f"   • Stake      : {row['stake']:.2f}u ({stake_desc})")
     print(f"   • Odds       : {row['market_odds']} | Book: {row['sportsbook']}")
+    # Debug: confirm the market probability at log time
+    print(f"   • Market Prob: {row['market_prob']*100:.1f}%")
     print(
         f"   • EV         : {row['ev_percent']:+.2f}% | Blended: {row['blended_prob']:.4f} | Edge: {edge:+.4f}\n"
     )


### PR DESCRIPTION
## Summary
- show the market probability when logging bets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483c378bec832c95b352c13759c623