### PR TITLE
Add stale lock check for market_eval_tracker

### DIFF
--- a/core/market_eval_tracker.py
+++ b/core/market_eval_tracker.py
@@ -45,6 +45,15 @@ def save_tracker(tracker: Dict[str, dict], path: str = TRACKER_PATH) -> None:
     lock = f"{path}.lock"
     tmp = f"{path}.tmp"
 
+    # Detect and clean up stale lock files before attempting to acquire the lock
+    if os.path.exists(lock):
+        try:
+            if time.time() - os.path.getmtime(lock) > 10:
+                print("⚠️ Stale tracker lock detected; removing old lock file")
+                os.remove(lock)
+        except Exception:
+            pass
+
     # Acquire an exclusive lock file, waiting briefly if another process holds it
     for _ in range(50):  # ~5 seconds max
         try:


### PR DESCRIPTION
## Summary
- add stale lock file detection before acquiring market eval tracker lock

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484ec807e0832cb0c5bba72af4b952