### PR TITLE
Add mismatch warning for CLV update

### DIFF
--- a/cli/update_clv_column.py
+++ b/cli/update_clv_column.py
@@ -81,6 +81,14 @@ def update_clv(csv_path, odds_json_path, target_date):
         )
         closing_odds = {}
 
+    json_has_time = any("-T" in k for k in closing_odds)
+    csv_has_time = any("-T" in row.get("game_id", "") for row in rows)
+
+    if json_has_time and not csv_has_time:
+        logger.warning(
+            "⚠️ Detected possible mismatch: JSON has -T time in game_ids, CSV does not. CLV matching may fail."
+        )
+
     updated_rows = []
     for row in rows:
         gid = canonical_game_id(row.get("game_id", ""))


### PR DESCRIPTION
## Summary
- warn when game_id format differs between CSV and closing odds JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848835bb480832c9db1118f872efbe7