### PR TITLE
Normalize best_book format during logging

### DIFF
--- a/cli/replay_skipped_bets.py
+++ b/cli/replay_skipped_bets.py
@@ -33,7 +33,6 @@ FIELDNAMES = [
     "entry_type",
     "segment",
     "segment_label",
-    "sportsbook",
     "best_book",
     "date_simulated",
     "result",

--- a/tests/test_discord_role_filter.py
+++ b/tests/test_discord_role_filter.py
@@ -31,11 +31,7 @@ def test_role_tagging_filters(monkeypatch):
                 "draftkings": -105,
                 "betmgm": 210,
             },
-            "best_book": {
-                "fanduel": -110,
-                "draftkings": -105,
-                "betmgm": 210,
-            },
+            "best_book": "fanduel",
         }
     )
 

--- a/tests/test_skip_logging_reasons.py
+++ b/tests/test_skip_logging_reasons.py
@@ -53,7 +53,7 @@ def test_top_up_skips_movement_check(monkeypatch, tmp_path):
     row["entry_type"] = "top-up"
     row["market_prob"] = 0.55
     row["_prior_snapshot"] = {"market_prob": 0.6}
-    row["sportsbook"] = "B1"
+    row["best_book"] = "B1"
     monkeypatch.setattr("utils.logging_allowed_now", lambda now=None: True)
     result = write_to_csv(row, tmp_path / "t.csv", {}, {}, {}, dry_run=False, force_log=False)
     assert result is not None

--- a/tests/test_write_to_csv_top_up.py
+++ b/tests/test_write_to_csv_top_up.py
@@ -26,7 +26,7 @@ def test_top_up_written_even_without_market_move(monkeypatch, tmp_path):
     row["full_stake"] = 1.6
     row["market_prob"] = 0.515
     row["_prior_snapshot"] = {"market_prob": 0.520}
-    row["sportsbook"] = "B1"
+    row["best_book"] = "B1"
 
     existing = {(row["game_id"], row["market"], row["side"]): 1.0}
 


### PR DESCRIPTION
## Summary
- ensure `consensus_books` always populated from `_raw_sportsbook` or `best_book`
- store clean `best_book` strings and consensus dicts when logging
- propagate consensus book normalization to snapshot expansion utilities
- update replay script and tests for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d119d3ec832cae2eb3d878360d42