### PR TITLE
Improve Discord header formatting

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -953,6 +953,8 @@ def get_market_class_emoji(segment_label: str) -> str:
     mapping = {
         "alt_line": "\U0001F4D0",  # 📐
         "derivative": "\U0001F9E9",  # 🧩
+        "team_total": "\U0001F3AF",  # 🎯
+        "pk_equiv": "\u2796",  # ➖
     }
     return mapping.get(segment_label, "\U0001F4CA")  # 📊 by default
 
@@ -1000,8 +1002,8 @@ def build_discord_embed(row: dict) -> str:
     market = row["market"]
 
     segment_label = row.get("segment_label", "mainline")
-    emoji = get_market_class_emoji(segment_label)
-    market_class_tag = f"{emoji} *{segment_label.replace('_', ' ').title()}*"
+    from utils import format_segment_header
+    segment_header = format_segment_header(segment_label)
 
     odds = row["market_odds"]
     if isinstance(odds, (int, float)) and odds > 0:
@@ -1136,7 +1138,7 @@ def build_discord_embed(row: dict) -> str:
     parts = [
         f"{tag} {header}",
         "",
-        f"{game_day_tag} | {market_class_tag} | 🏷 {segment_label}",
+        f"{game_day_tag} | {segment_header}",
         f"🏟️ Game: **{event_label}**",
         f"🧾 Market: **{market} — {side}**",
         f"💰 Stake: **{stake:.2f}u @ {odds}** → {bet_label}",

--- a/tests/test_format_segment_header.py
+++ b/tests/test_format_segment_header.py
@@ -1,0 +1,16 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import format_segment_header
+
+
+def test_mainline_suppresses_tag():
+    assert format_segment_header("mainline").endswith("Mainline*")
+    assert "\U0001F3F7" not in format_segment_header("mainline")
+
+
+def test_team_total_keeps_tag():
+    out = format_segment_header("team_total")
+    assert "\U0001F3AF" in out  # emoji
+    assert "\U0001F3F7" in out  # tag emoji
+    assert out.endswith("team_total")

--- a/utils.py
+++ b/utils.py
@@ -320,6 +320,30 @@ def get_segment_label(market_key: str, side: str) -> str:
     return "mainline"
 
 
+def format_segment_header(segment_label: str) -> str:
+    """Return emoji and label for a segment, avoiding redundant tags."""
+
+    if not segment_label:
+        segment_label = "mainline"
+
+    emoji_map = {
+        "mainline": "\U0001F4CA",  # 📊
+        "alt_line": "\U0001F4D0",  # 📐
+        "derivative": "\U0001F9E9",  # 🧩
+        "team_total": "\U0001F3AF",  # 🎯
+        "pk_equiv": "\u2796",  # ➖
+    }
+
+    emoji = emoji_map.get(segment_label, "\U0001F4CA")
+    label_display = segment_label.replace("_", " ").title()
+    header = f"{emoji} *{label_display}*"
+
+    if segment_label in {"mainline", "alt_line", "derivative"}:
+        return header
+
+    return f"{header} | \U0001F3F7 {segment_label}" if segment_label else header
+
+
 
 
 def normalize_to_abbreviation(label: str) -> str:


### PR DESCRIPTION
## Summary
- centralize segment header formatting in `format_segment_header`
- integrate helper into Discord embed generation
- extend emoji mapping
- test header formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d8d80ca0832cb8e82bb9e0395e63