### PR TITLE
Fix role tagging to use blended EV

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1107,7 +1107,9 @@ def build_discord_embed(row: dict) -> str:
     if isinstance(all_odds_dict, dict):
         for book, price in all_odds_dict.items():
             try:
-                ev_map[book.lower()] = (sim_prob * to_decimal(float(price)) - 1) * 100
+                ev_map[book.lower()] = (
+                    blended_prob * to_decimal(float(price)) - 1
+                ) * 100
             except Exception:
                 continue
 

--- a/tests/test_discord_notification.py
+++ b/tests/test_discord_notification.py
@@ -77,3 +77,20 @@ def test_no_extra_roles_line_when_none_qualify():
     msg = build_discord_embed(row)
     lines = [ln.strip() for ln in msg.splitlines()]
     assert "📣" not in lines[-1]
+
+
+def test_role_tagging_uses_blended_prob():
+    row = _base_row()
+    row.update(
+        {
+            "_raw_sportsbook": {"DraftKings": -120},
+            "best_book": "DraftKings",
+            "sim_prob": 0.6,
+            "blended_prob": 0.52,
+            "ev_percent": -4.7,
+            "market_odds": -120,
+        }
+    )
+    msg = build_discord_embed(row)
+    lines = [ln.strip() for ln in msg.splitlines()]
+    assert "📣" not in lines[-1]


### PR DESCRIPTION
## Summary
- use blended_prob for EV mapping in Discord alerts
- ensure role tagging only triggers when blended EV% >= 5
- add regression test for blended probability logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e1bcab04832ca301061a2e6f46fe