### PR TITLE
Add debug log when start time missing in log_bets

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1611,6 +1611,10 @@ def log_bets(
         return
 
     start_dt = odds_start_times.get(game_id)
+    if not start_dt:
+        print(
+            f"⚠️ No start time found for game_id: {game_id} — defaulting to 8.0 hours"
+        )
     hours_to_game = 8.0
     if start_dt:
         hours_to_game = compute_hours_to_game(start_dt)


### PR DESCRIPTION
## Summary
- log warning when game start time is unavailable in `log_bets`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2274021c832cb91ee3bd4397ac94