### PR TITLE
Enable persistent diff highlights for snapshots

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -308,8 +308,6 @@ def run_unified_snapshot_and_dispatch(odds_path: str):
         "dispatch_sim_only_snapshot.py",
     ]:
         cmd = [PYTHON, f"core/{script}", "--output-discord"]
-        if script != "dispatch_sim_only_snapshot.py":
-            cmd.append("--diff-highlight")
 
         launch_process(script, cmd)
 

--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -52,7 +52,6 @@ def main() -> None:
     )
     parser.add_argument("--date", default=None, help="Filter by game date")
     parser.add_argument("--output-discord", action="store_true")
-    parser.add_argument("--diff-highlight", action="store_true")
     parser.add_argument(
         "--min-ev",
         type=float,
@@ -97,7 +96,7 @@ def main() -> None:
         args.max_ev,
     )
 
-    df = format_for_display(rows, include_movement=args.diff_highlight)
+    df = format_for_display(rows, include_movement=True)
     if "sim_prob_display" in df.columns:
         df["Sim %"] = df["sim_prob_display"]
     if "mkt_prob_display" in df.columns:

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -118,7 +118,6 @@ def main() -> None:
     parser.add_argument("--snapshot-path", default=None, help="Path to unified snapshot JSON")
     parser.add_argument("--date", default=None, help="Filter by game date")
     parser.add_argument("--output-discord", action="store_true")
-    parser.add_argument("--diff-highlight", action="store_true")
     parser.add_argument(
         "--books",
         default=os.getenv("FV_DROP_BOOKS"),
@@ -173,7 +172,7 @@ def main() -> None:
 
 
 
-    df = format_for_display(rows, include_movement=args.diff_highlight)
+    df = format_for_display(rows, include_movement=True)
     if "sim_prob_display" in df.columns:
         df["Sim %"] = df["sim_prob_display"]
     if "mkt_prob_display" in df.columns:

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -50,7 +50,6 @@ def main() -> None:
     )
     parser.add_argument("--date", default=None, help="Filter by game date")
     parser.add_argument("--output-discord", action="store_true")
-    parser.add_argument("--diff-highlight", action="store_true")
     parser.add_argument(
         "--min-ev",
         type=float,
@@ -95,7 +94,7 @@ def main() -> None:
         args.max_ev,
     )
 
-    df = format_for_display(rows, include_movement=args.diff_highlight)
+    df = format_for_display(rows, include_movement=True)
     if "sim_prob_display" in df.columns:
         df["Sim %"] = df["sim_prob_display"]
     if "mkt_prob_display" in df.columns:

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -65,7 +65,6 @@ def main() -> None:
     parser.add_argument("--snapshot-path", default=None, help="Path to unified snapshot JSON")
     parser.add_argument("--date", default=None, help="Filter by game date")
     parser.add_argument("--output-discord", action="store_true")
-    parser.add_argument("--diff-highlight", action="store_true")
     parser.add_argument(
         "--min-ev",
         type=float,
@@ -110,7 +109,7 @@ def main() -> None:
         args.max_ev,
     )
 
-    df = format_for_display(rows, include_movement=args.diff_highlight)
+    df = format_for_display(rows, include_movement=True)
     allowed_books = ["pinnacle", "fanduel", "bovada", "betonlineag"]
     df = filter_by_books(df, allowed_books)
     if "sim_prob_display" in df.columns:

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -239,11 +239,6 @@ def build_argument_parser(
             "--debug-json", default=None, help="Path to write debug output"
         )
     parser.add_argument(
-        "--diff-highlight",
-        action="store_true",
-        help="Highlight new rows and odds movements",
-    )
-    parser.add_argument(
         "--reset-snapshot",
         action="store_true",
         help="Clear stored snapshot before running",
@@ -596,6 +591,11 @@ def compare_and_flag_new_rows(
             entry,
             MARKET_EVAL_TRACKER,
             MARKET_EVAL_TRACKER_BEFORE_UPDATE,
+        )
+        entry["is_new"] = (
+            key not in MARKET_EVAL_TRACKER_BEFORE_UPDATE
+            and key not in last_snapshot
+            and key not in prior_data
         )
         annotate_display_deltas(entry, prior)
         blended_fv = entry.get("blended_fv", entry.get("fair_odds"))

--- a/core/snapshots/best_book_snapshot_generator.py
+++ b/core/snapshots/best_book_snapshot_generator.py
@@ -185,7 +185,7 @@ def main():
         logger.warning("⚠️ No qualifying bets found.")
         return
 
-    df = format_for_display(rows, include_movement=args.diff_highlight)
+    df = format_for_display(rows, include_movement=True)
 
     df_all_export = format_for_display(flagged_rows, include_movement=False)
     df_all_export = df_all_export.drop(
@@ -240,10 +240,7 @@ def main():
         else:
             logger.error("❌ No Discord webhook configured for best-book snapshots.")
     else:
-        if args.diff_highlight:
-            print(format_table_with_highlights(rows))
-        else:
-            print(df.to_string(index=False))
+        print(df.to_string(index=False))
 
     os.makedirs(os.path.dirname(snapshot_path), exist_ok=True)
     with open(snapshot_path, "w") as f:

--- a/core/snapshots/fv_drop_snapshot_generator.py
+++ b/core/snapshots/fv_drop_snapshot_generator.py
@@ -226,7 +226,7 @@ def main():
     if args.output_discord and WEBHOOK_URL:
         send_bet_snapshot_to_discord(df, "FV Drop", WEBHOOK_URL)
     else:
-        print(format_table_with_highlights(rows))
+        print(df.to_string(index=False))
         if args.output_discord and not WEBHOOK_URL:
             logger.warning("⚠️ Discord webhook is not configured for FV drop snapshots.")
 

--- a/core/snapshots/live_snapshot_generator.py
+++ b/core/snapshots/live_snapshot_generator.py
@@ -152,7 +152,7 @@ def main():
         logger.warning("⚠️ No qualifying bets found.")
         return
 
-    df = format_for_display(rows, include_movement=args.diff_highlight)
+    df = format_for_display(rows, include_movement=True)
 
     df_all_export = format_for_display(flagged_rows, include_movement=False)
     df_export = df_all_export.drop(
@@ -186,10 +186,7 @@ def main():
                 continue
             send_bet_snapshot_to_discord(subset, mkt, webhook)
     else:
-        if args.diff_highlight:
-            print(format_table_with_highlights(rows))
-        else:
-            print(df.to_string(index=False))
+        print(df.to_string(index=False))
 
     # Save snapshot for next run
     os.makedirs(os.path.dirname(snapshot_path), exist_ok=True)

--- a/core/snapshots/personal_snapshot_generator.py
+++ b/core/snapshots/personal_snapshot_generator.py
@@ -130,7 +130,7 @@ def main():
         logger.warning("⚠️ No qualifying bets found.")
         return
 
-    df = format_for_display(rows, include_movement=args.diff_highlight)
+    df = format_for_display(rows, include_movement=True)
 
     df_all_export = format_for_display(flagged_rows, include_movement=False)
     df_export = df_all_export.drop(
@@ -153,10 +153,7 @@ def main():
     if args.output_discord:
         send_bet_snapshot_to_discord(df, "MLB Markets", PERSONAL_WEBHOOK_URL)
     else:
-        if args.diff_highlight:
-            print(format_table_with_highlights(rows))
-        else:
-            print(df.to_string(index=False))
+        print(df.to_string(index=False))
 
     os.makedirs(os.path.dirname(snapshot_path), exist_ok=True)
     with open(snapshot_path, "w") as f:


### PR DESCRIPTION
## Summary
- always include movement columns when formatting snapshot tables
- mark snapshot rows as new only once using tracker + prior snapshots
- enable green row highlight in image-based snapshot tables
- drop `--diff-highlight` flag from snapshot commands and auto loop
- output plain tables to console

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad74eddac832c91e81bf9a684d2d7