### PR TITLE
Add CLV snapshot dispatch to auto loop

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -311,6 +311,10 @@ def run_unified_snapshot_and_dispatch(odds_path: str):
 
         launch_process(script, cmd)
 
+    # Dispatch CLV snapshot after other role-based snapshots
+    clv_cmd = [PYTHON, "core/dispatch_clv_snapshot.py", "--output-discord"]
+    launch_process("dispatch_clv_snapshot.py", clv_cmd)
+
 
 logger.info(
     "🔄 [%s] Starting auto loop... "


### PR DESCRIPTION
## Summary
- dispatch CLV snapshot every 5 minutes alongside other snapshot feeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae037f13c832c95fb5dbcf910468f