### PR TITLE
Add fallback when consensus odds missing

### DIFF
--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -211,8 +211,13 @@ def build_snapshot_rows(csv_rows: list, odds_data: dict) -> list:
         start_dt = parse_start_time(gid, game_odds)
         if start_dt and start_dt <= now:
             continue
-        consensus_prob = lookup_consensus_prob(game_odds, row.get("market", ""), row.get("side", ""))
+        market = row.get("market", "")
+        side = row.get("side", "")
+        consensus_prob = lookup_consensus_prob(game_odds, market, side)
         if consensus_prob is None:
+            logger.warning(
+                "⚠️ No consensus price for game=%s market=%s side=%s", gid, market, side
+            )
             continue
         try:
             bet_odds = float(row.get("market_odds"))

--- a/tests/test_dispatch_clv_snapshot.py
+++ b/tests/test_dispatch_clv_snapshot.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import logging
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.dispatch_clv_snapshot import build_snapshot_rows
+
+
+def test_skip_row_when_consensus_missing(caplog):
+    rows = [
+        {
+            "game_id": "2030-06-09-MIL@CIN-T1305",
+            "market": "h2h",
+            "side": "MIL",
+            "market_odds": "110",
+        }
+    ]
+    odds = {}  # no odds data for game
+    with caplog.at_level(logging.WARNING, logger="core.dispatch_clv_snapshot"):
+        result = build_snapshot_rows(rows, odds)
+    assert result == []
+    assert any("consensus price" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- warn and skip when consensus market price not found
- add regression test for missing consensus price

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae364ac00832ca99a4ac8cf83fe14