### PR TITLE
Improve CLV snapshot label matching

### DIFF
--- a/tests/test_dispatch_clv_snapshot.py
+++ b/tests/test_dispatch_clv_snapshot.py
@@ -7,6 +7,10 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from core.dispatch_clv_snapshot import build_snapshot_rows
 
 
+def _row(game_id, market, side, odds="110"):
+    return {"game_id": game_id, "market": market, "side": side, "market_odds": odds}
+
+
 def test_skip_row_when_consensus_missing(caplog):
     rows = [
         {
@@ -21,3 +25,34 @@ def test_skip_row_when_consensus_missing(caplog):
         result = build_snapshot_rows(rows, odds)
     assert result == []
     assert any("consensus price" in rec.message for rec in caplog.records)
+
+
+def test_lookup_with_normalized_labels():
+    gid = "2030-06-09-WAS@NYM-T1905"
+
+    rows = [_row(gid, "totals", "Over 8.5")]
+    odds = {
+        gid: {
+            "alternate_totals": {
+                "Over 8.5": {"consensus_prob": 0.55}
+            }
+        }
+    }
+
+    result = build_snapshot_rows(rows, odds)
+    assert len(result) == 1
+
+
+def test_lookup_team_name_vs_abbr():
+    gid = "2030-06-09-WAS@NYM-T1905"
+    rows = [_row(gid, "spreads", "Washington Nationals +1.5")]
+    odds = {
+        gid: {
+            "spreads": {
+                "WSH +1.5": {"consensus_prob": 0.5}
+            }
+        }
+    }
+
+    result = build_snapshot_rows(rows, odds)
+    assert len(result) == 1


### PR DESCRIPTION
## Summary
- normalize market and side labels when looking up consensus odds
- fall back to alternate lines when necessary
- test CLV snapshot label normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae6734178832c985d46f80d8ccf70