### PR TITLE
Batch missing consensus odds warnings

### DIFF
--- a/tests/test_dispatch_clv_snapshot.py
+++ b/tests/test_dispatch_clv_snapshot.py
@@ -24,7 +24,7 @@ def test_skip_row_when_consensus_missing(caplog):
     with caplog.at_level(logging.WARNING, logger="core.dispatch_clv_snapshot"):
         result = build_snapshot_rows(rows, odds)
     assert result == []
-    assert any("consensus price" in rec.message for rec in caplog.records)
+    assert any("Skipped 1 bets" in rec.message for rec in caplog.records)
 
 
 def test_lookup_with_normalized_labels():


### PR DESCRIPTION
## Summary
- suppress repeated CLV warnings for missing consensus odds
- add optional `--verbose` flag to `dispatch_clv_snapshot.py`
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae80c48b0832caf382ac6875ea2f9