### PR TITLE
Implement market confidence proxy in blend_prob

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1706,8 +1706,15 @@ def log_bets(
             book_prices = {fallback_source: market_price}
 
         p_market = consensus_prob if consensus_prob else implied_prob(market_price)
+        book_odds_list = [implied_prob(v) for v in book_prices.values()]
         p_blended, w_model, p_model, _ = blend_prob(
-            sim_prob, market_price, market_key, hours_to_game, p_market
+            sim_prob,
+            market_price,
+            market_key,
+            hours_to_game,
+            p_market,
+            book_odds_list=book_odds_list,
+            line_move=0.0,
         )
 
         ev_calc = calculate_ev_from_prob(p_blended, market_price)
@@ -2012,12 +2019,15 @@ def log_derivative_bets(
                 else:
                     p_market = implied_prob(market_price)
 
+                book_odds_list = [implied_prob(v) for v in book_prices.values()]
                 p_blended, w_model, p_model, _ = blend_prob(
                     p_model=prob,
                     market_odds=market_price,
                     market_type=market_key,
                     hours_to_game=hours_to_game,
                     p_market=p_market,
+                    book_odds_list=book_odds_list,
+                    line_move=0.0,
                 )
 
                 print(

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -802,8 +802,15 @@ def build_snapshot_rows(
                 label=lookup_side,
             )
             consensus_prob = result.get("consensus_prob")
+            book_odds_list = list(result.get("bookwise_probs", {}).values())
             p_blended, _, _, p_market = blend_prob(
-                sim_prob, price, market, hours_to_game, consensus_prob
+                sim_prob,
+                price,
+                market,
+                hours_to_game,
+                consensus_prob,
+                book_odds_list=book_odds_list,
+                line_move=0.0,
             )
             ev_pct = calculate_ev_from_prob(p_blended, price)
             stake_fraction = 0.125 if price_source == "alternate" else 0.25


### PR DESCRIPTION
## Summary
- compute market confidence proxy based on book disagreement and line movement
- adjust blend weight using proxy in `blend_prob`
- pass per-book implied probabilities to `blend_prob`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b061aec6c832ca18a1823e03ea339