### PR TITLE
Add dynamic market confirmation threshold

### DIFF
--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -1,0 +1,34 @@
+"""Utilities for confirming market signals."""
+
+from __future__ import annotations
+
+__all__ = ["required_market_move"]
+
+
+def required_market_move(hours_to_game: float) -> float:
+    """Return required consensus probability movement for confirmation.
+
+    Parameters
+    ----------
+    hours_to_game : float
+        Hours until game time.
+
+    Returns
+    -------
+    float
+        Minimum consensus implied probability delta.
+
+    Notes
+    -----
+    A base movement unit of ``0.006`` (approximate 20-cent move at one book)
+    is scaled by a linear decay multiplier that ranges from ``3.0`` 24 hours
+    before the game to ``1.0`` at game time.
+    """
+    movement_unit = 0.006
+    if hours_to_game is None:
+        hours = 0.0
+    else:
+        hours = float(hours_to_game)
+    clamped = min(max(hours, 0.0), 24.0)
+    multiplier = 1.0 + 2.0 * clamped / 24.0
+    return multiplier * movement_unit

--- a/tests/test_confirmation_utils.py
+++ b/tests/test_confirmation_utils.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pytest
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.confirmation_utils import required_market_move
+
+
+def test_required_market_move_endpoints():
+    assert required_market_move(0) == pytest.approx(0.006)
+    assert required_market_move(24) == pytest.approx(0.018)
+    # Hours beyond 24h should cap at 24h threshold
+    assert required_market_move(36) == pytest.approx(0.018)
+
+
+def test_required_market_move_midpoint():
+    expected = (1.0 + 2.0 * 12 / 24.0) * 0.006
+    assert required_market_move(12) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- implement `required_market_move` for market confirmation thresholds
- test market confirmation thresholds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2fd2a4f0832c86d899bd9d4c127a