### PR TITLE
Implement confirmation strength utility

### DIFF
--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["required_market_move"]
+__all__ = ["required_market_move", "confirmation_strength"]
 
 
 def required_market_move(hours_to_game: float) -> float:
@@ -32,3 +32,26 @@ def required_market_move(hours_to_game: float) -> float:
     clamped = min(max(hours, 0.0), 24.0)
     multiplier = 1.0 + 2.0 * clamped / 24.0
     return multiplier * movement_unit
+
+
+def confirmation_strength(observed_move: float, hours_to_game: float) -> float:
+    """Return the market confirmation strength for a bet.
+
+    Parameters
+    ----------
+    observed_move : float
+        The consensus implied probability change observed in the market.
+    hours_to_game : float
+        Hours until game time used to determine the required threshold.
+
+    Returns
+    -------
+    float
+        A normalized strength value between 0 and 1 where ``1`` means the
+        observed move meets or exceeds the required threshold.
+    """
+
+    threshold = required_market_move(hours_to_game)
+    if threshold <= 0:
+        return 1.0
+    return min(1.0, float(observed_move) / threshold)

--- a/tests/test_confirmation_utils.py
+++ b/tests/test_confirmation_utils.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.confirmation_utils import required_market_move
+from core.confirmation_utils import required_market_move, confirmation_strength
 
 
 def test_required_market_move_endpoints():
@@ -16,3 +16,11 @@ def test_required_market_move_endpoints():
 def test_required_market_move_midpoint():
     expected = (1.0 + 2.0 * 12 / 24.0) * 0.006
     assert required_market_move(12) == pytest.approx(expected)
+
+
+def test_confirmation_strength_example():
+    hours = 12
+    required = required_market_move(hours)
+    strength = confirmation_strength(0.009, hours)
+    assert required == pytest.approx(0.012)
+    assert strength == pytest.approx(0.009 / required)


### PR DESCRIPTION
## Summary
- add `confirmation_strength` helper in `confirmation_utils`
- test confirmation strength logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b31079a80832c8f1db1072ba51df5