### PR TITLE
Add pending early bet recheck

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -1,0 +1,131 @@
+import os
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import (
+    parse_game_id,
+    EASTERN_TZ,
+    now_eastern,
+)
+from core.time_utils import compute_hours_to_game
+from core.odds_fetcher import fetch_consensus_for_single_game, american_to_prob
+from core.confirmation_utils import required_market_move
+from core.pending_bets import (
+    load_pending_bets,
+    save_pending_bets,
+    PENDING_BETS_PATH,
+)
+from core.theme_exposure_tracker import load_tracker as load_theme_stakes, save_tracker as save_theme_stakes
+from core.market_eval_tracker import load_tracker as load_eval_tracker
+from cli.log_betting_evals import write_to_csv, load_existing_stakes
+from core.should_log_bet import should_log_bet
+
+CHECK_INTERVAL = 30 * 60  # 30 minutes
+
+
+def _start_time_from_gid(game_id: str) -> datetime | None:
+    parts = parse_game_id(game_id)
+    date = parts.get("date")
+    time_part = parts.get("time", "")
+    if not date:
+        return None
+    if time_part.startswith("T"):
+        raw = time_part.split("-")[0][1:]
+        try:
+            dt = datetime.strptime(f"{date} {raw}", "%Y-%m-%d %H%M")
+            return dt.replace(tzinfo=EASTERN_TZ)
+        except Exception:
+            return None
+    try:
+        return datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=EASTERN_TZ)
+    except Exception:
+        return None
+
+
+def recheck_pending_bets(path: str = PENDING_BETS_PATH) -> None:
+    pending = load_pending_bets(path)
+    if not pending:
+        return
+
+    existing = load_existing_stakes("logs/market_evals.csv")
+    session_exposure = defaultdict(set)
+    theme_stakes = load_theme_stakes()
+    eval_tracker = load_eval_tracker()
+
+    updated = {}
+    for key, bet in pending.items():
+        start_dt = _start_time_from_gid(bet["game_id"])
+        if not start_dt:
+            continue
+        hours_to_game = compute_hours_to_game(start_dt)
+        if hours_to_game <= 0:
+            # Game started; drop entry
+            continue
+        market_data = fetch_consensus_for_single_game(bet["game_id"])
+        if not market_data:
+            updated[key] = bet
+            continue
+        market = market_data.get(bet["market"], {})
+        label_key = next(
+            (k for k in market if k.lower() == bet["side"].lower()),
+            None,
+        )
+        if not label_key:
+            updated[key] = bet
+            continue
+        price = market[label_key].get("price")
+        new_prob = american_to_prob(price) if price is not None else None
+        if new_prob is None:
+            updated[key] = bet
+            continue
+        prev_prob = bet.get("baseline_consensus_prob")
+        if prev_prob is None:
+            prev_prob = bet.get("consensus_prob")
+        try:
+            movement = float(new_prob) - float(prev_prob)
+        except Exception:
+            movement = 0.0
+        if movement < required_market_move(hours_to_game):
+            updated[key] = bet
+            continue
+        row = bet.copy()
+        row["consensus_prob"] = new_prob
+        row["market_prob"] = new_prob
+        row["hours_to_game"] = hours_to_game
+        ref = {key: {"consensus_prob": prev_prob}}
+        evaluated = should_log_bet(
+            row,
+            theme_stakes,
+            verbose=False,
+            eval_tracker=eval_tracker,
+            reference_tracker=ref,
+        )
+        if evaluated:
+            result = write_to_csv(
+                evaluated,
+                "logs/market_evals.csv",
+                existing,
+                session_exposure,
+                theme_stakes,
+            )
+            if result:
+                save_theme_stakes(theme_stakes)
+                continue
+        updated[key] = bet
+
+    if updated != pending:
+        save_pending_bets(updated, path)
+
+
+def main() -> None:
+    while True:
+        recheck_pending_bets()
+        time.sleep(CHECK_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/pending_bets.py
+++ b/core/pending_bets.py
@@ -1,0 +1,34 @@
+import os
+import json
+from datetime import datetime
+
+from utils import safe_load_json, now_eastern
+
+PENDING_BETS_PATH = os.path.join('logs', 'pending_bets.json')
+
+
+def load_pending_bets(path: str = PENDING_BETS_PATH) -> dict:
+    """Return dictionary of pending bets keyed by tracker key."""
+    data = safe_load_json(path)
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def save_pending_bets(pending: dict, path: str = PENDING_BETS_PATH) -> None:
+    """Persist ``pending`` to ``path`` atomically."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = f"{path}.tmp"
+    with open(tmp, 'w') as f:
+        json.dump(pending, f, indent=2)
+    os.replace(tmp, path)
+
+
+def queue_pending_bet(bet: dict, path: str = PENDING_BETS_PATH) -> None:
+    """Append or update ``bet`` in ``pending_bets.json``."""
+    pending = load_pending_bets(path)
+    key = f"{bet['game_id']}:{bet['market']}:{bet['side']}"
+    bet_copy = {k: v for k, v in bet.items() if not k.startswith('_')}
+    bet_copy['queued_ts'] = datetime.now().isoformat()
+    pending[key] = bet_copy
+    save_pending_bets(pending, path)

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -228,6 +228,17 @@ def should_log_bet(
                 f"⛔ should_log_bet: Early bet suppressed — movement {movement:.3f} < {threshold:.3f}",
                 verbose,
             )
+            try:
+                from core.pending_bets import queue_pending_bet
+
+                queue_pending_bet(
+                    {
+                        **new_bet,
+                        "baseline_consensus_prob": prev_prob,
+                    }
+                )
+            except Exception:
+                pass
             new_bet["entry_type"] = "none"
             new_bet["skip_reason"] = "suppressed_early_unconfirmed"
             return None

--- a/tests/test_pending_bets.py
+++ b/tests/test_pending_bets.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import json
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.should_log_bet import should_log_bet
+from core import pending_bets
+
+
+def test_queue_pending_bet(monkeypatch, tmp_path):
+    path = tmp_path / "pending.json"
+
+    orig = pending_bets.queue_pending_bet
+
+    def queue(bet):
+        orig(bet, str(path))
+
+    monkeypatch.setattr(pending_bets, "queue_pending_bet", queue)
+
+    bet = {
+        "game_id": "gid",
+        "market": "totals",
+        "side": "Over 8.5",
+        "full_stake": 1.0,
+        "ev_percent": 6.0,
+        "market_prob": 0.55,
+        "hours_to_game": 10,
+    }
+    tracker_key = f"{bet['game_id']}:{bet['market']}:Over 8.5"
+    reference = {tracker_key: {"market_prob": bet["market_prob"]}}
+
+    res = should_log_bet(bet, {}, verbose=False, reference_tracker=reference)
+    assert res is None
+    data = pending_bets.load_pending_bets(str(path))
+    key = f"{bet['game_id']}:{bet['market']}:{bet['side']}"
+    assert key in data
+    queued = data[key]
+    assert queued["full_stake"] == bet["full_stake"]
+    assert queued["baseline_consensus_prob"] == bet["market_prob"]


### PR DESCRIPTION
## Summary
- save suppressed early bets using `core.pending_bets`
- re-evaluate queued bets in new `monitor_early_bets.py`
- queue suppressed bets in `should_log_bet`
- test queuing of pending bets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3ab20498832cbe77e792a229db6b