### PR TITLE
Add threshold debug table generator

### DIFF
--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-__all__ = ["required_market_move", "confirmation_strength"]
+__all__ = [
+    "required_market_move",
+    "confirmation_strength",
+    "print_threshold_table",
+]
 
 
 def required_market_move(hours_to_game: float) -> float:
@@ -55,3 +59,19 @@ def confirmation_strength(observed_move: float, hours_to_game: float) -> float:
     if threshold <= 0:
         return 1.0
     return min(1.0, float(observed_move) / threshold)
+
+
+def print_threshold_table() -> None:
+    """Print required market move thresholds at key hours.
+
+    The table shows how much consensus line movement is needed for
+    confirmation at selected hours leading up to a game.
+    """
+
+    key_hours = [24, 18, 12, 6, 3, 1, 0]
+    print("[Hours to Game] | [Required Move (%)] | [Movement Units]")
+    for hours in key_hours:
+        threshold = required_market_move(hours)
+        percent = threshold * 100.0
+        units = threshold / 0.006
+        print(f"{hours:>3}h | {percent:>6.3f}% | {units:>5.2f}")

--- a/tests/test_confirmation_utils.py
+++ b/tests/test_confirmation_utils.py
@@ -3,7 +3,11 @@ import sys
 import pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.confirmation_utils import required_market_move, confirmation_strength
+from core.confirmation_utils import (
+    required_market_move,
+    confirmation_strength,
+    print_threshold_table,
+)
 
 
 def test_required_market_move_endpoints():
@@ -24,3 +28,17 @@ def test_confirmation_strength_example():
     strength = confirmation_strength(0.009, hours)
     assert required == pytest.approx(0.012)
     assert strength == pytest.approx(0.009 / required)
+
+
+def test_print_threshold_table_output(capsys):
+    print_threshold_table()
+    out_lines = [line.strip() for line in capsys.readouterr().out.splitlines()]
+    expected_header = "[Hours to Game] | [Required Move (%)] | [Movement Units]"
+    assert out_lines[0] == expected_header
+    key_hours = [24, 18, 12, 6, 3, 1, 0]
+    for idx, hours in enumerate(key_hours, start=1):
+        threshold = required_market_move(hours)
+        percent = threshold * 100.0
+        units = threshold / 0.006
+        expected = f"{hours:>3}h | {percent:>6.3f}% | {units:>5.2f}".strip()
+        assert out_lines[idx] == expected


### PR DESCRIPTION
## Summary
- add a debug helper to print required market move thresholds
- test the new threshold output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3fb35e00832cb069c72246bd9194