### PR TITLE
Implement late confirmation top-up logic

### DIFF
--- a/core/bet_manager.py
+++ b/core/bet_manager.py
@@ -1,0 +1,107 @@
+"""Utilities for managing bet entries and top-ups."""
+
+from typing import Optional
+
+from core.confirmation_utils import required_market_move, confirmation_strength
+from core.market_pricer import kelly_fraction
+from core.should_log_bet import MIN_TOPUP_STAKE
+
+
+def evaluate_late_confirmed_bet(
+    bet: dict,
+    new_consensus_prob: float,
+    existing_stake: float,
+) -> Optional[dict]:
+    """Return a top-up bet if late confirmation warrants additional stake.
+
+    Parameters
+    ----------
+    bet : dict
+        Original bet information as logged when first evaluated. Must
+        contain ``hours_to_game`` and ``full_stake`` keys. If
+        ``baseline_consensus_prob`` is present it is used as the
+        reference; otherwise ``consensus_prob`` is used.
+    new_consensus_prob : float
+        The latest consensus probability for the bet's line.
+    existing_stake : float
+        Units already staked on this bet.
+
+    Returns
+    -------
+    dict | None
+        A bet dictionary marked as ``"top-up"`` with the additional stake to
+        place, or ``None`` if no action is required.
+    """
+
+    try:
+        hours = float(bet.get("hours_to_game"))
+    except Exception:
+        return None
+
+    try:
+        prev_prob = bet.get("baseline_consensus_prob")
+        if prev_prob is None:
+            prev_prob = bet.get("consensus_prob")
+        prev_prob = float(prev_prob)
+    except Exception:
+        return None
+
+    try:
+        new_prob = float(new_consensus_prob)
+    except Exception:
+        return None
+
+    movement = new_prob - prev_prob
+    if movement < required_market_move(hours):
+        return None
+
+    prob = (
+        bet.get("blended_prob")
+        or bet.get("sim_prob")
+        or bet.get("consensus_prob")
+        or new_prob
+    )
+    odds = bet.get("market_odds")
+    if odds is None:
+        return None
+
+    try:
+        prob_val = float(prob)
+        odds_val = float(odds)
+    except Exception:
+        return None
+
+    fraction = 0.125 if bet.get("market_class") == "alternate" else 0.25
+    raw_kelly = bet.get("raw_kelly")
+    if raw_kelly is None:
+        raw_kelly = kelly_fraction(prob_val, odds_val, fraction=fraction)
+    try:
+        raw_kelly = float(raw_kelly)
+    except Exception:
+        raw_kelly = 0.0
+
+    strength = confirmation_strength(movement, hours)
+    target_stake = round(raw_kelly * (strength ** 1.5), 4)
+
+    try:
+        max_full = float(bet.get("full_stake", target_stake))
+    except Exception:
+        max_full = target_stake
+
+    target_stake = min(target_stake, max_full)
+    delta = round(target_stake - float(existing_stake), 2)
+
+    if delta < MIN_TOPUP_STAKE:
+        return None
+
+    updated = bet.copy()
+    updated.update(
+        {
+            "stake": delta,
+            "full_stake": target_stake,
+            "entry_type": "top-up",
+            "consensus_prob": new_prob,
+            "market_prob": new_prob,
+        }
+    )
+    return updated

--- a/tests/test_bet_manager.py
+++ b/tests/test_bet_manager.py
@@ -1,0 +1,40 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.bet_manager import evaluate_late_confirmed_bet
+from core.confirmation_utils import required_market_move
+
+
+def _base_bet():
+    return {
+        "game_id": "gid",
+        "market": "totals",
+        "side": "Over 8.5",
+        "market_odds": 110,
+        "blended_prob": 0.55,
+        "full_stake": 3.0,
+        "hours_to_game": 5.0,
+        "baseline_consensus_prob": 0.52,
+    }
+
+
+def test_top_up_triggered_when_movement_meets_threshold():
+    bet = _base_bet()
+    threshold = required_market_move(bet["hours_to_game"])
+    new_prob = bet["baseline_consensus_prob"] + threshold + 0.002
+
+    res = evaluate_late_confirmed_bet(bet, new_prob, existing_stake=1.0)
+    assert res is not None
+    assert res["entry_type"] == "top-up"
+    assert res["stake"] == 2.0
+    assert res["full_stake"] <= bet["full_stake"]
+
+
+def test_no_top_up_when_movement_insufficient():
+    bet = _base_bet()
+    threshold = required_market_move(bet["hours_to_game"])
+    new_prob = bet["baseline_consensus_prob"] + threshold - 0.001
+
+    res = evaluate_late_confirmed_bet(bet, new_prob, existing_stake=1.0)
+    assert res is None


### PR DESCRIPTION
## Summary
- add `evaluate_late_confirmed_bet` in `bet_manager.py`
- test top‑up evaluation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b44155964832c9d815e30d7be73c9