### PR TITLE
Fix log_bets strength handling

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1756,7 +1756,13 @@ def log_bets(
         stake_fraction = 0.125 if price_source == "alternate" else 0.25
 
         raw_kelly = kelly_fraction(p_blended, market_price, fraction=stake_fraction)
-        stake = round(raw_kelly * (strength ** 1.5), 4)
+        try:
+            stake = round(
+                raw_kelly * (max(0.0, float(strength)) ** 1.5),
+                4,
+            )
+        except (TypeError, ValueError):
+            stake = 0.0
 
         print(
             f"📝 Logging → game: {game_id} | market: {matched_key} | side: '{side_clean}' | normalized: '{lookup_side}' | source: {price_source} | segment: {segment}"


### PR DESCRIPTION
## Summary
- prevent TypeError in `log_bets` when confirmation strength isn't a float
- guard the strength value before using it to compute stake

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b45c21cd8832c9d0d39496fb54642