### PR TITLE
Fix negative confirmation strength

### DIFF
--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -59,7 +59,7 @@ def confirmation_strength(observed_move: float, hours_to_game: float) -> float:
     threshold = required_market_move(hours_to_game)
     if threshold <= 0:
         return 1.0
-    return min(1.0, float(observed_move) / threshold)
+    return max(0.0, min(1.0, float(observed_move) / threshold))
 
 
 def print_threshold_table() -> None:

--- a/tests/test_confirmation_utils.py
+++ b/tests/test_confirmation_utils.py
@@ -31,6 +31,15 @@ def test_confirmation_strength_example():
     assert strength == pytest.approx(0.009 / required)
 
 
+def test_confirmation_strength_clamped():
+    hours = 10
+    # Negative observed move should yield minimum strength of 0.0
+    assert confirmation_strength(-0.005, hours) == 0.0
+    # Observed move well above threshold should clamp to 1.0
+    large_move = required_market_move(hours) * 2
+    assert confirmation_strength(large_move, hours) == 1.0
+
+
 def test_print_threshold_table_output(capsys):
     print_threshold_table()
     out_lines = [line.strip() for line in capsys.readouterr().out.splitlines()]


### PR DESCRIPTION
## Summary
- clamp `confirmation_strength` to avoid negative values
- add tests for strength clamping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5c4f56e8832c9f0efa450f375bcb