### PR TITLE
Remove blend_weight_model from skipped bet CSV output

### DIFF
--- a/cli/replay_skipped_bets.py
+++ b/cli/replay_skipped_bets.py
@@ -28,7 +28,6 @@ FIELDNAMES = [
     "blended_prob",
     "blended_fv",
     "hours_to_game",
-    "blend_weight_model",
     "stake",
     "entry_type",
     "segment",


### PR DESCRIPTION
## Summary
- adjust `FIELDNAMES` in `replay_skipped_bets.py`
- remove obsolete `blend_weight_model` column from fallback CSV output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7dfba6f0832c82ceac35e33fe380