### PR TITLE
Enforce canonical bet log schema

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1511,8 +1511,6 @@ def write_to_csv(
         "blended_prob",
         "blended_fv",
         "hours_to_game",
-        "raw_kelly",
-        "adjusted_kelly",
         "stake",
         "entry_type",
         "segment",


### PR DESCRIPTION
## Summary
- drop debug fields `raw_kelly` and `adjusted_kelly` from `write_to_csv`
- keep computation of kelly values in memory for diagnostics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b87beb650832c9411b7eddfd3e32b