### PR TITLE
Add Start Time ISO column to replay skipped bets

### DIFF
--- a/cli/replay_skipped_bets.py
+++ b/cli/replay_skipped_bets.py
@@ -9,6 +9,7 @@ from utils import canonical_game_id, parse_game_id
 FIELDNAMES = [
     "Date",
     "Time",
+    "Start Time (ISO)",
     "Matchup",
     "game_id",
     "market",


### PR DESCRIPTION
## Summary
- keep market eval headers consistent with added Start Time (ISO)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b88cd327c832c81f4bf7a125d489c