### PR TITLE
Support dict skipped bet logs

### DIFF
--- a/cli/replay_skipped_bets.py
+++ b/cli/replay_skipped_bets.py
@@ -48,10 +48,15 @@ def load_skipped(path):
         except Exception as e:
             print(f"Failed to parse {path}: {e}")
             return []
-    if not isinstance(data, list):
-        print(f"Invalid format in {path}")
-        return []
-    return data
+
+    if isinstance(data, dict):
+        return list(data.values())
+
+    if isinstance(data, list):
+        return data
+
+    print(f"Warning: unexpected format in {path}; expected list or dict")
+    return []
 
 def load_existing_keys(csv_path):
     keys = set()


### PR DESCRIPTION
## Summary
- handle `pending_bets.json` dict format in `replay_skipped_bets`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2142947c832c8ca4094109634aff