### PR TITLE
Add success log for CLV snapshot dispatch

### DIFF
--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -352,7 +352,7 @@ def send_snapshot(df: pd.DataFrame, webhook_url: str) -> None:
             timeout=10,
         )
         resp.raise_for_status()
-        logger.info("✅ CLV snapshot sent (%d rows)", df.shape[0])
+        logger.info(f"✅ CLV Snapshot sent with {df.shape[0]} rows")
     except Exception as e:
         logger.error("❌ Failed to send snapshot: %s", e)
     finally:


### PR DESCRIPTION
## Summary
- log when dispatching CLV snapshot succeeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c270264c0832cae2408a312db2224