### PR TITLE
Fix .env loading for dispatch scripts

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -10,7 +10,8 @@ from utils import safe_load_json
 import argparse
 from dotenv import load_dotenv
 
-load_dotenv(dotenv_path="C:/Users/jason/OneDrive/Documents/Projects/odds-gpt/mlb_odds_engine_V1.1/.env")
+# Load environment variables from the project root .env file
+load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -13,7 +13,8 @@ import re
 import pandas as pd
 from dotenv import load_dotenv
 
-load_dotenv(dotenv_path="C:/Users/jason/OneDrive/Documents/Projects/odds-gpt/mlb_odds_engine_V1.1/.env")
+# Load environment variables from the project root .env file
+load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -10,7 +10,8 @@ from utils import safe_load_json
 import argparse
 from dotenv import load_dotenv
 
-load_dotenv(dotenv_path="C:/Users/jason/OneDrive/Documents/Projects/odds-gpt/mlb_odds_engine_V1.1/.env")
+# Load environment variables from the project root .env file
+load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -12,7 +12,8 @@ from typing import List
 import pandas as pd
 from dotenv import load_dotenv
 
-load_dotenv(dotenv_path="C:/Users/jason/OneDrive/Documents/Projects/odds-gpt/mlb_odds_engine_V1.1/.env")
+# Load environment variables from the project root .env file
+load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger


### PR DESCRIPTION
## Summary
- make dispatch scripts load `.env` from project root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2ab7633c832ca10a48357556fa07