### PR TITLE
Add pending bet summary script

### DIFF
--- a/scripts/print_pending_summary.py
+++ b/scripts/print_pending_summary.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Print a summary of pending bets."""
+
+import os
+import sys
+import argparse
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.append(ROOT_DIR)
+
+from utils import safe_load_json
+
+DEFAULT_JSON = os.path.join("logs", "pending_bets.json")
+
+
+def load_bets(path: str) -> list:
+    """Load pending bets from ``path`` and return them as a list."""
+    if not os.path.exists(path):
+        print(f"\u274c No pending bets file found at: {path}")
+        return []
+
+    data = safe_load_json(path)
+    if data is None:
+        return []
+
+    if isinstance(data, dict):
+        return list(data.values())
+    if isinstance(data, list):
+        return data
+
+    print(f"\u274c Unexpected format in {path} (expected dict or list)")
+    return []
+
+
+def print_summary(bets: list) -> int:
+    """Print count and up to 5 sample bets. Return the bet count."""
+    count = len(bets)
+    print(f"Pending bets: {count}")
+
+    for bet in bets[:5]:
+        game_id = bet.get("game_id", "N/A")
+        market = bet.get("market", "N/A")
+        side = bet.get("side", "N/A")
+        reason = bet.get("reason") or bet.get("skip_reason") or "N/A"
+        print(f"- {game_id} | {market} | {side} | {reason}")
+
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show summary of pending bets")
+    parser.add_argument(
+        "--json",
+        default=DEFAULT_JSON,
+        help="Path to pending_bets.json",
+    )
+    args = parser.parse_args()
+
+    bets = load_bets(args.json)
+    count = print_summary(bets)
+
+    if count:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `scripts` package and new CLI `print_pending_summary.py`
- implement loader to handle dict or list formats
- show count and up to 5 bet samples; exit with non-zero status when bets exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c30708fc4832c84321d69cee882f5