### PR TITLE
Adjust debug printing

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -40,8 +40,12 @@ DEBUG = False
 SHOW_PENDING = False
 
 
-def log_segment_mismatch(sim_segment: str, book_segment: str) -> None:
+def log_segment_mismatch(sim_segment: str, book_segment: str, debug: bool = False) -> None:
     """Print a segment mismatch message with truncation after a limit."""
+    debug = debug or DEBUG_MODE or VERBOSE_MODE
+    if not debug:
+        return
+
     global segment_skip_count
     segment_skip_count += 1
     if segment_skip_count <= SEGMENT_SKIP_LIMIT:


### PR DESCRIPTION
## Summary
- import DEBUG_MODE and VERBOSE_MODE
- only print matcher traces when DEBUG_MODE is on
- gate segment mismatch logs behind DEBUG_MODE/VERBOSE_MODE

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3a56b1c8832c8ea5352fd31d2071