### PR TITLE
Refactor shared book helpers

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -23,6 +23,7 @@ from dotenv import load_dotenv
 from core.market_eval_tracker import load_tracker, save_tracker, build_tracker_key
 from utils import safe_load_json, now_eastern, EASTERN_TZ, parse_game_id
 from utils import canonical_game_id
+from utils.book_helpers import ensure_consensus_books
 import re
 
 load_dotenv()
@@ -1653,17 +1654,6 @@ def write_to_csv(
 
     return row
 
-
-def ensure_consensus_books(row):
-    """Populate ``row['consensus_books']`` with a clean book:odds mapping."""
-
-    if "consensus_books" not in row or not row["consensus_books"]:
-        if isinstance(row.get("_raw_sportsbook"), dict) and row["_raw_sportsbook"]:
-            row["consensus_books"] = row["_raw_sportsbook"]
-        elif isinstance(row.get("best_book"), str) and isinstance(
-            row.get("market_odds"), (int, float)
-        ):
-            row["consensus_books"] = {row["best_book"]: row["market_odds"]}
 
 
 def log_bets(

--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
-from utils.snapshot_filters import filter_snapshot_rows
+from utils.book_helpers import filter_snapshot_rows
 from core.logger import get_logger
 
 logger = get_logger(__name__)

--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -33,7 +33,7 @@ from utils import (
 from core.logger import get_logger
 from core.odds_fetcher import american_to_prob
 from core.market_pricer import calculate_clv_and_fv
-from utils.snapshot_filters import filter_snapshot_rows
+from utils.book_helpers import filter_snapshot_rows
 
 try:
     import dataframe_image as dfi

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -20,6 +20,7 @@ load_dotenv()
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
 from core.should_log_bet import MAX_POSITIVE_ODDS, MIN_NEGATIVE_ODDS
+from utils.book_helpers import parse_american_odds, filter_by_odds
 
 logger = get_logger(__name__)
 
@@ -59,40 +60,6 @@ def filter_by_books(df: pd.DataFrame, books: List[str] | None) -> pd.DataFrame:
     return df[df["Book"].isin(clean_books)]
 
 
-def parse_american_odds(val: str | float | int | None) -> float | None:
-    """Return numeric US odds from various input formats."""
-    if val is None:
-        return None
-    if isinstance(val, (int, float)):
-        try:
-            return float(val)
-        except Exception:
-            return None
-    if isinstance(val, str):
-        s = val.strip()
-        if not s or s.upper() == "N/A":
-            return None
-        try:
-            return float(s)
-        except Exception:
-            m = re.match(r"^[+-]?\d+", s)
-            if m:
-                try:
-                    return float(m.group())
-                except Exception:
-                    return None
-    return None
-
-
-def filter_by_odds(df: pd.DataFrame, min_odds: float, max_odds: float) -> pd.DataFrame:
-    """Return df filtered to the given odds range."""
-    if "Odds" not in df.columns:
-        return df
-    df = df.copy()
-    df["_odds_val"] = df["Odds"].apply(parse_american_odds)
-    df = df[df["_odds_val"].between(min_odds, max_odds)]
-    df.drop(columns=["_odds_val"], inplace=True)
-    return df
 
 
 def filter_main_lines(df: pd.DataFrame) -> pd.DataFrame:

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
-from utils.snapshot_filters import filter_snapshot_rows
+from utils.book_helpers import filter_snapshot_rows
 from core.logger import get_logger
 
 logger = get_logger(__name__)

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -49,6 +49,8 @@ from core.market_movement_tracker import track_and_update_market_movement
 from core.market_eval_tracker import load_tracker, save_tracker, build_tracker_key
 import copy
 
+from utils.book_helpers import ensure_consensus_books
+
 # Load tracker once for snapshot utilities and keep a frozen copy for comparisons
 MARKET_EVAL_TRACKER = load_tracker()
 MARKET_EVAL_TRACKER_BEFORE_UPDATE = copy.deepcopy(MARKET_EVAL_TRACKER)
@@ -57,17 +59,6 @@ MARKET_EVAL_TRACKER_BEFORE_UPDATE = copy.deepcopy(MARKET_EVAL_TRACKER)
 MOVEMENT_LOG_LIMIT = 5
 movement_log_count = 0
 
-
-def ensure_consensus_books(row: Dict) -> None:
-    """Ensure ``row['consensus_books']`` is populated consistently."""
-
-    if "consensus_books" not in row or not row["consensus_books"]:
-        if isinstance(row.get("_raw_sportsbook"), dict) and row["_raw_sportsbook"]:
-            row["consensus_books"] = row["_raw_sportsbook"]
-        elif isinstance(row.get("best_book"), str) and isinstance(
-            row.get("market_odds"), (int, float)
-        ):
-            row["consensus_books"] = {row["best_book"]: row["market_odds"]}
 
 
 def should_log_movement() -> bool:

--- a/tests/test_market_prob_filter.py
+++ b/tests/test_market_prob_filter.py
@@ -7,9 +7,11 @@ import pandas as pd
 from core.dispatch_fv_drop_snapshot import (
     is_market_prob_increasing,
     filter_by_books,
+    filter_main_lines,
+)
+from utils.book_helpers import (
     parse_american_odds,
     filter_by_odds,
-    filter_main_lines,
 )
 
 

--- a/utils/book_helpers.py
+++ b/utils/book_helpers.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple, Dict, Any
+import re
+import pandas as pd
+
+
+def parse_american_odds(val: str | float | int | None) -> float | None:
+    """Return numeric US odds from various input formats."""
+    if val is None:
+        return None
+    if isinstance(val, (int, float)):
+        try:
+            return float(val)
+        except Exception:
+            return None
+    if isinstance(val, str):
+        s = val.strip()
+        if not s or s.upper() == "N/A":
+            return None
+        try:
+            return float(s)
+        except Exception:
+            m = re.match(r"^[+-]?\d+", s)
+            if m:
+                try:
+                    return float(m.group())
+                except Exception:
+                    return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Odds range helpers
+# ---------------------------------------------------------------------------
+
+def _get_odds_value(row: Dict[str, Any]) -> float | None:
+    for key in ("market_odds", "odds", "odds_display"):
+        if key in row:
+            val = parse_american_odds(row.get(key))
+            if val is not None:
+                return val
+    return None
+
+
+def filter_snapshot_rows(
+    rows: Iterable[Dict[str, Any]],
+    min_ev: float = 3,
+    odds_range: Tuple[float, float] = (-150, 200),
+) -> list[Dict[str, Any]]:
+    """Return rows filtered by EV% and odds range."""
+    min_odds, max_odds = odds_range
+    result = []
+    for r in rows:
+        try:
+            ev = float(r.get("ev_percent", 0))
+        except Exception:
+            ev = 0.0
+        if ev < min_ev:
+            continue
+        odds_val = _get_odds_value(r)
+        if odds_val is not None and not (min_odds <= odds_val <= max_odds):
+            continue
+        result.append(r)
+    return result
+
+
+def filter_by_odds(df: pd.DataFrame, min_odds: float, max_odds: float) -> pd.DataFrame:
+    """Return df filtered to the given odds range."""
+    if "Odds" not in df.columns:
+        return df
+    df = df.copy()
+    df["_odds_val"] = df["Odds"].apply(parse_american_odds)
+    df = df[df["_odds_val"].between(min_odds, max_odds)]
+    df.drop(columns=["_odds_val"], inplace=True)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Book helpers
+# ---------------------------------------------------------------------------
+
+def ensure_consensus_books(row: Dict) -> None:
+    """Ensure ``row['consensus_books']`` is populated consistently."""
+    if "consensus_books" not in row or not row["consensus_books"]:
+        if isinstance(row.get("_raw_sportsbook"), dict) and row["_raw_sportsbook"]:
+            row["consensus_books"] = row["_raw_sportsbook"]
+        elif isinstance(row.get("best_book"), str) and isinstance(row.get("market_odds"), (int, float)):
+            row["consensus_books"] = {row["best_book"]: row["market_odds"]}
+
+

--- a/utils/snapshot_filters.py
+++ b/utils/snapshot_filters.py
@@ -1,60 +1,11 @@
 from __future__ import annotations
 
-from typing import Iterable, Tuple, Dict, Any
-import re
+from utils.book_helpers import (
+    parse_american_odds,
+    filter_snapshot_rows,
+)
 
-
-def parse_american_odds(val: str | float | int | None) -> float | None:
-    """Return numeric odds from various representations."""
-    if val is None:
-        return None
-    if isinstance(val, (int, float)):
-        try:
-            return float(val)
-        except Exception:
-            return None
-    if isinstance(val, str):
-        s = val.strip()
-        if not s or s.upper() == "N/A":
-            return None
-        try:
-            return float(s)
-        except Exception:
-            m = re.match(r"^[+-]?\d+", s)
-            if m:
-                try:
-                    return float(m.group())
-                except Exception:
-                    return None
-    return None
-
-
-def _get_odds_value(row: Dict[str, Any]) -> float | None:
-    for key in ("market_odds", "odds", "odds_display"):
-        if key in row:
-            val = parse_american_odds(row.get(key))
-            if val is not None:
-                return val
-    return None
-
-
-def filter_snapshot_rows(
-    rows: Iterable[Dict[str, Any]],
-    min_ev: float = 3,
-    odds_range: Tuple[float, float] = (-150, 200),
-) -> list[Dict[str, Any]]:
-    """Return rows filtered by EV% and odds range."""
-    min_odds, max_odds = odds_range
-    result = []
-    for r in rows:
-        try:
-            ev = float(r.get("ev_percent", 0))
-        except Exception:
-            ev = 0.0
-        if ev < min_ev:
-            continue
-        odds_val = _get_odds_value(r)
-        if odds_val is not None and not (min_odds <= odds_val <= max_odds):
-            continue
-        result.append(r)
-    return result
+__all__ = [
+    "parse_american_odds",
+    "filter_snapshot_rows",
+]


### PR DESCRIPTION
## Summary
- centralize book helper functions in utils/book_helpers.py
- use new module across snapshot code and CLI
- update odds dispatch scripts to import helpers
- adjust tests for new helper locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4d40d2b8832c995372106c76a6b8