### PR TITLE
Add safe flag to full_slate_runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ python cli/run_distribution_simulator.py 2025-04-04-TEX@HOU
 
 Simulate and price entire slate:
 python cli/full_slate_runner.py 2025-04-04 --csv
+# Use --safe to skip corrupt game data
+python cli/full_slate_runner.py 2025-04-04 --safe
 
 Track closing line value:
 python cli/closing_odds_monitor.py


### PR DESCRIPTION
## Summary
- add --safe option to skip failed games
- warn on simulation failures instead of erroring out
- document the new flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4f301044832c8d4a0bc1c8ef0add