### PR TITLE
Add market evals backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ These tools help measure closing line value (CLV) for your logged bets.
 * **update_clv_column.py** – merges the saved closing odds back into
   `market_evals.csv`, calculating `clv_percent`, `model_clv_percent` and a
   `clv_class` label for quick filtering.
+* **backup_market_evals.py** – copies `logs/market_evals.csv` to `logs/backups/market_evals_YYYYMMDD.csv` for safekeeping.
 
 
 📈 Output Fields

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -24,6 +24,7 @@ A simplified flow diagram:
 ## Expected Folders & Files
 
 - `logs/` – rolling CSV logs like `market_evals.csv` and `bet_history.csv`.
+- `logs/backups/` – timestamped backups created by `backup_market_evals.py`.
 - `backtest/sims/` – saved simulation results and `market_snapshot_*.json` files.
 - `data/trackers/` – JSON trackers such as `market_conf_tracker.json` for stateful processes.
 

--- a/tools/backup_market_evals.py
+++ b/tools/backup_market_evals.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Backup the logs/market_evals.csv file with a timestamp."""
+import os
+import shutil
+from datetime import datetime
+
+
+def backup_market_evals(src_path: str = "logs/market_evals.csv", backup_dir: str = "logs/backups") -> None:
+    """Copy ``src_path`` to ``backup_dir`` with a datestamped filename."""
+    if not os.path.exists(src_path):
+        print(f"❌ Source not found: {src_path}")
+        return
+
+    os.makedirs(backup_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d")
+    dest_path = os.path.join(backup_dir, f"market_evals_{timestamp}.csv")
+
+    shutil.copy2(src_path, dest_path)
+    print(f"✅ Backed up {src_path} → {dest_path}")
+
+
+if __name__ == "__main__":
+    backup_market_evals()
+


### PR DESCRIPTION
## Summary
- add `backup_market_evals.py` to copy logs/market_evals.csv to timestamped backups
- document backup script in README and data_flow docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c513998d4832caa5025ffd62e8e09