### PR TITLE
Refactor CLI imports with bootstrap

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -2,23 +2,15 @@ from core import config
 import argparse
 import sys
 import os
+from dotenv import load_dotenv
+from core.logger import get_logger
 
-import sys
+from core.bootstrap import *  # noqa
 
-if sys.version_info >= (3, 7):
-    import os
-
-    os.environ["PYTHONIOENCODING"] = "utf-8"
-
-# Ensure project root is on the path regardless of where this script is invoked
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.append(ROOT_DIR)
 PYTHON = sys.executable
 
-from dotenv import load_dotenv
-
 load_dotenv()
-from core.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/cli/bankroll_manager.py
+++ b/cli/bankroll_manager.py
@@ -1,7 +1,7 @@
 import sys
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core.bootstrap import *  # noqa
 
 
 import numpy as np

--- a/cli/closing_odds_fetcher.py
+++ b/cli/closing_odds_fetcher.py
@@ -4,6 +4,7 @@ import csv
 import json
 import argparse
 from dotenv import load_dotenv
+from core.bootstrap import *  # noqa
 
 from core.odds_fetcher import (
     fetch_consensus_for_single_game,

--- a/cli/closing_odds_monitor.py
+++ b/cli/closing_odds_monitor.py
@@ -1,8 +1,7 @@
 import sys
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/cli/daily_odds_fetcher.py
+++ b/cli/daily_odds_fetcher.py
@@ -1,7 +1,7 @@
 import sys
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/cli/full_slate_runner.py
+++ b/cli/full_slate_runner.py
@@ -5,21 +5,15 @@ import os
 import json
 import re
 from datetime import date
+from core.bootstrap import *  # noqa
 
-import sys
-if sys.version_info >= (3, 7):
-    import os
-    os.environ["PYTHONIOENCODING"] = "utf-8"
-
-# Add project root to sys.path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.logger import get_logger
 logger = get_logger(__name__)
 
 # === Core Modules ===
 from assets.probable_pitchers import fetch_probable_pitchers
-from run_distribution_simulator import simulate_distribution
+from cli.run_distribution_simulator import simulate_distribution
 from utils import canonical_game_id
 
 

--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1,15 +1,7 @@
 # === Path Setup ===
 from core import config
 import os, sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-import sys
-
-if sys.version_info >= (3, 7):
-    import os
-
-    os.environ["PYTHONIOENCODING"] = "utf-8"
+from core.bootstrap import *  # noqa
 
 # === Core Imports ===
 import json, csv, math, argparse

--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -3,8 +3,7 @@ import sys
 import time
 from collections import defaultdict
 from datetime import datetime
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 from utils import (
     parse_game_id,

--- a/cli/replay_pending_bets.py
+++ b/cli/replay_pending_bets.py
@@ -4,6 +4,7 @@ import csv
 import json
 import os
 from datetime import datetime
+from core.bootstrap import *  # noqa
 
 from utils import canonical_game_id, parse_game_id
 

--- a/cli/replay_skipped_bets.py
+++ b/cli/replay_skipped_bets.py
@@ -1,4 +1,5 @@
-from replay_pending_bets import main
+from cli.replay_pending_bets import main
+from core.bootstrap import *  # noqa
 
 if __name__ == "__main__":
     main()

--- a/cli/run_distribution_simulator.py
+++ b/cli/run_distribution_simulator.py
@@ -14,8 +14,7 @@ import tempfile
 import matplotlib.pyplot as plt
 from collections import Counter
 from datetime import datetime
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/cli/update_clv_column.py
+++ b/cli/update_clv_column.py
@@ -4,9 +4,7 @@ import argparse
 from datetime import datetime, timedelta
 import os
 import sys
-
-# 🔁 Add project root to sys.path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+os.environ["PYTHONIOENCODING"] = "utf-8"

--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -2,7 +2,7 @@
 from core import config
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 """Dispatch best-book snapshot from unified snapshot JSON."""
 

--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -13,8 +13,7 @@ from datetime import datetime
 import pandas as pd
 import requests
 from dotenv import load_dotenv
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 from utils import (
     parse_game_id,

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -2,7 +2,7 @@
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 """Dispatch FV drop snapshot (market probability increases) from unified snapshot JSON."""
 

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -2,7 +2,7 @@
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 """Dispatch live snapshot from unified snapshot JSON."""
 

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -2,7 +2,7 @@
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 """Dispatch personal-book snapshot from unified snapshot JSON."""
 

--- a/core/dispatch_sim_only_snapshot.py
+++ b/core/dispatch_sim_only_snapshot.py
@@ -8,8 +8,7 @@ import json
 import io
 from typing import List
 import argparse
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.bootstrap import *  # noqa
 
 from dotenv import load_dotenv
 import pandas as pd

--- a/core/snapshots/best_book_snapshot_generator.py
+++ b/core/snapshots/best_book_snapshot_generator.py
@@ -2,14 +2,7 @@
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import sys
-
-import sys
-if sys.version_info >= (3, 7):
-    import os
-    os.environ["PYTHONIOENCODING"] = "utf-8"
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "cli")))
+from core.bootstrap import *  # noqa
 
 import json
 from datetime import datetime

--- a/core/snapshots/fv_drop_snapshot_generator.py
+++ b/core/snapshots/fv_drop_snapshot_generator.py
@@ -2,14 +2,7 @@
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import sys
-
-import sys
-if sys.version_info >= (3, 7):
-    import os
-    os.environ["PYTHONIOENCODING"] = "utf-8"
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "cli")))
+from core.bootstrap import *  # noqa
 
 import json
 from datetime import datetime

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -14,9 +14,7 @@ import json
 import argparse
 import shutil
 from datetime import timedelta
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "cli")))
+from core.bootstrap import *  # noqa
 
 from utils import now_eastern, safe_load_json, lookup_fallback_odds
 from core.logger import get_logger

--- a/scripts/print_pending_summary.py
+++ b/scripts/print_pending_summary.py
@@ -5,10 +5,7 @@ from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import sys
 import argparse
-
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if ROOT_DIR not in sys.path:
-    sys.path.append(ROOT_DIR)
+from core.bootstrap import *  # noqa
 
 from utils import safe_load_json
 


### PR DESCRIPTION
## Summary
- centralize sys.path setup in new `core/bootstrap.py`
- clean up each CLI to use package-relative imports
- ensure dispatch and snapshot scripts import from `core.bootstrap`
- update relative imports like `replay_pending_bets` and `run_distribution_simulator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c616f615c832c8dbb49f9400fee2d