### PR TITLE
Add start_time_iso to simulator output

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -992,6 +992,27 @@ def canonical_game_id(game_id: str) -> str:
         return game_id
 
 
+def game_id_to_dt(game_id: str) -> datetime | None:
+    """Return a :class:`datetime` for the Eastern start time encoded in ``game_id``."""
+    parts = parse_game_id(game_id)
+    date = parts.get("date")
+    time_token = parts.get("time", "")
+    dt = None
+    if time_token.startswith("T"):
+        digits = "".join(c for c in time_token.split("-")[0][1:] if c.isdigit())[:4]
+        if len(digits) == 4:
+            try:
+                dt = datetime.strptime(f"{date} {digits}", "%Y-%m-%d %H%M")
+            except Exception:
+                dt = None
+    if dt is None and date:
+        try:
+            dt = datetime.strptime(date, "%Y-%m-%d")
+        except Exception:
+            dt = None
+    return dt.replace(tzinfo=EASTERN_TZ) if dt else None
+
+
 def lookup_fallback_odds(game_id: str, fallback_odds: dict) -> dict | None:
     """Return the best-matching fallback odds entry for ``game_id``."""
     if not isinstance(fallback_odds, dict):


### PR DESCRIPTION
## Summary
- cache daily odds in `run_distribution_simulator`
- inject start_time_iso into each simulation JSON output
- provide helper `game_id_to_dt` for fallback conversion from game_id to datetime

## Testing
- `pytest -q`
- `python -m cli.full_slate_runner 2025-05-22 --no-weather --safe` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_684c733e197c832cb39adc2c214470ed