### PR TITLE
Consolidate stake thresholds

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -165,16 +165,13 @@ def should_log_bet(
             new_bet["skip_reason"] = "bad_odds"
             return None
 
-    if ev < min_ev * 100 or stake < min_stake:
+    if ev < min_ev * 100:
         if verbose:
             print(
-                f"⛔ should_log_bet: Rejected due to EV/stake threshold → EV: {ev:.2f}%, Stake: {stake:.2f}u"
+                f"⛔ should_log_bet: Rejected due to EV threshold → EV: {ev:.2f}%"
             )
         new_bet["entry_type"] = "none"
-        if ev < min_ev * 100:
-            new_bet["skip_reason"] = "low_ev"
-        elif stake < min_stake:
-            new_bet["skip_reason"] = "low_stake"
+        new_bet["skip_reason"] = "low_ev"
         return None
 
     base_market = market.replace("alternate_", "")
@@ -303,7 +300,7 @@ def should_log_bet(
                 verbose,
             )
             new_bet["entry_type"] = "none"
-            new_bet["skip_reason"] = "low_stake"
+            new_bet["skip_reason"] = "low_initial"
             return None
         _log_verbose(
             f"✅ should_log_bet: First bet → {side} | {theme_key} [{segment}] | Stake: {stake:.2f}u | EV: {ev:.2f}%",
@@ -317,14 +314,6 @@ def should_log_bet(
     if delta >= MIN_TOPUP_STAKE:
         new_bet["stake"] = delta
         new_bet["entry_type"] = "top-up"
-        if new_bet["stake"] < MIN_TOPUP_STAKE:
-            msg = (
-                f"⛔ Delta stake {new_bet['stake']:.2f}u < {MIN_TOPUP_STAKE:.1f}u minimum"
-            )
-            _log_verbose(msg, verbose)
-            new_bet["entry_type"] = "none"
-            new_bet["skip_reason"] = msg
-            return None
         _log_verbose(
             f"🔼 should_log_bet: Top-up accepted → {side} | {theme_key} [{segment}] | Δ {delta:.2f}u",
             verbose,
@@ -333,6 +322,6 @@ def should_log_bet(
 
     msg = f"⛔ Delta stake {delta:.2f}u < {MIN_TOPUP_STAKE:.1f}u minimum"
     new_bet["entry_type"] = "none"
-    new_bet["skip_reason"] = msg
+    new_bet["skip_reason"] = "low_topup"
     _log_verbose(msg, verbose)
     return None

--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -65,7 +65,7 @@ def test_top_up_rejected_for_small_delta():
     result = should_log_bet(bet, existing_theme_stakes, verbose=False, eval_tracker=tracker)
     assert result is None
     assert bet["entry_type"] == "none"
-    assert bet["skip_reason"] == "⛔ Delta stake 0.20u < 0.5u minimum"
+    assert bet["skip_reason"] == "low_topup"
 
 
 def test_top_up_rejected_for_delta_point_three():
@@ -200,10 +200,10 @@ def test_rejected_for_low_stake():
         "ev_percent": 6.0,
     }
 
-    result = should_log_bet(bet, {}, verbose=False, min_stake=1.0)
+    result = should_log_bet(bet, {}, verbose=False)
     assert result is None
     assert bet["entry_type"] == "none"
-    assert bet["skip_reason"] == "low_stake"
+    assert bet["skip_reason"] == "low_initial"
 
 
 def test_rejected_for_odds_too_high():


### PR DESCRIPTION
## Summary
- centralize first bet and top‑up stake thresholds inside `should_log_bet`
- remove duplicate checks from `log_betting_evals`
- update tests for new skip reasons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccb2a43cc832c98651108ca312e0f