### PR TITLE
Fix skipped bet counting

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -2629,6 +2629,8 @@ def process_theme_logged_bets(
         SkipReason.LOW_INITIAL.value: 0,
         SkipReason.LOW_TOPUP.value: 0,
         SkipReason.ALREADY_LOGGED.value: 0,
+        "low_ev": 0,
+        "low_stake": 0,
     }
 
     stake_mode = "model"  # or "actual" if you're filtering only logged bets


### PR DESCRIPTION
## Summary
- avoid KeyError for missing skip reasons by initializing all known skip keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd8c8e70c832cb0c9a18f5f2ce7df