### PR TITLE
Fix skip counting

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -2746,7 +2746,7 @@ def process_theme_logged_bets(
 
                 if not evaluated:
                     reason = row_copy.get("skip_reason", "skipped")
-                    skipped_counts[reason] += 1
+                    skipped_counts[reason] = skipped_counts.get(reason, 0) + 1
                     if should_include_in_summary(row):
                         row["skip_reason"] = reason
                         ensure_consensus_books(row)


### PR DESCRIPTION
## Summary
- avoid KeyError for unknown skip reasons when logging bets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cdc6d4d24832ca643b33c653ffee1