### PR TITLE
Centralize CLI bootstrap usage

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -2,10 +2,9 @@ from core import config
 import argparse
 import sys
 import os
+from core.bootstrap import *  # noqa
 from dotenv import load_dotenv
 from core.logger import get_logger
-
-from core.bootstrap import *  # noqa
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 PYTHON = sys.executable

--- a/cli/bankroll_manager.py
+++ b/cli/bankroll_manager.py
@@ -1,7 +1,7 @@
 import sys
-from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 from core.bootstrap import *  # noqa
+from core.config import DEBUG_MODE, VERBOSE_MODE
 
 
 import numpy as np

--- a/cli/closing_odds_fetcher.py
+++ b/cli/closing_odds_fetcher.py
@@ -1,10 +1,10 @@
 import os
+from core.bootstrap import *  # noqa
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import csv
 import json
 import argparse
 from dotenv import load_dotenv
-from core.bootstrap import *  # noqa
 
 from core.odds_fetcher import (
     fetch_consensus_for_single_game,

--- a/cli/closing_odds_monitor.py
+++ b/cli/closing_odds_monitor.py
@@ -1,7 +1,7 @@
 import sys
-from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 from core.bootstrap import *  # noqa
+from core.config import DEBUG_MODE, VERBOSE_MODE
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/cli/daily_odds_fetcher.py
+++ b/cli/daily_odds_fetcher.py
@@ -1,7 +1,7 @@
 import sys
-from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 from core.bootstrap import *  # noqa
+from core.config import DEBUG_MODE, VERBOSE_MODE
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/cli/full_slate_runner.py
+++ b/cli/full_slate_runner.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-from core.config import DEBUG_MODE, VERBOSE_MODE
 import sys
 import os
+from core.bootstrap import *  # noqa
+from core.config import DEBUG_MODE, VERBOSE_MODE
 import json
 import re
 from datetime import date
-from core.bootstrap import *  # noqa
 
 
 from core.logger import get_logger

--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1,6 +1,7 @@
 # === Path Setup ===
 from core import config
-import os, sys
+import os
+import sys
 from core.bootstrap import *  # noqa
 
 # === Core Imports ===

--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -1,9 +1,9 @@
 import os
 import sys
+from core.bootstrap import *  # noqa
 import time
 from collections import defaultdict
 from datetime import datetime
-from core.bootstrap import *  # noqa
 
 from utils import (
     parse_game_id,

--- a/cli/run_distribution_simulator.py
+++ b/cli/run_distribution_simulator.py
@@ -8,13 +8,13 @@ from core.config import DEBUG_MODE, VERBOSE_MODE
 import re
 import sys
 import os
+from core.bootstrap import *  # noqa
 import json
 import numpy as np
 import tempfile
 import matplotlib.pyplot as plt
 from collections import Counter
 from datetime import datetime
-from core.bootstrap import *  # noqa
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/cli/update_clv_column.py
+++ b/cli/update_clv_column.py
@@ -1,10 +1,10 @@
 import csv
-from core.config import DEBUG_MODE, VERBOSE_MODE
-import argparse
-from datetime import datetime, timedelta
 import os
 import sys
 from core.bootstrap import *  # noqa
+from core.config import DEBUG_MODE, VERBOSE_MODE
+import argparse
+from datetime import datetime, timedelta
 
 from core.logger import get_logger
 logger = get_logger(__name__)

--- a/scripts/print_pending_summary.py
+++ b/scripts/print_pending_summary.py
@@ -4,8 +4,8 @@
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import sys
-import argparse
 from core.bootstrap import *  # noqa
+import argparse
 
 from utils import safe_load_json
 


### PR DESCRIPTION
## Summary
- import `core.bootstrap` right after `os`/`sys` in CLI modules
- keep CLI startup logic consistent across scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cdd57646c832ca1d5b9182ff0a6ae