### PR TITLE
Add skipped bets disk logging

### DIFF
--- a/tests/test_save_skipped_bets.py
+++ b/tests/test_save_skipped_bets.py
@@ -1,0 +1,20 @@
+import json
+import os
+from cli.log_betting_evals import save_skipped_bets
+
+
+def test_save_skipped_bets(tmp_path):
+    bets = [{
+        "game_id": "gid",
+        "market": "h2h",
+        "side": "TeamA",
+        "ev_percent": 5.5,
+        "stake": 1.0,
+        "skip_reason": "low_ev",
+    }]
+    path = save_skipped_bets(bets, base_dir=str(tmp_path))
+    assert os.path.exists(path)
+    assert not os.path.exists(path + ".tmp")
+    with open(path) as f:
+        data = json.load(f)
+    assert data == bets


### PR DESCRIPTION
## Summary
- optionally save skipped bets in `log_betting_evals.py`
- new CLI flag `--no_save_skips`
- helper `save_skipped_bets` for atomic JSON writes
- tests for saving skipped bets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cdecdd7e4832cb8e76ec43fe43dec