### PR TITLE
Add debug logging for high EV bets

### DIFF
--- a/core/scaling_utils.py
+++ b/core/scaling_utils.py
@@ -127,7 +127,7 @@ def blend_prob(
         is the combined probability and ``w_model`` is the weight applied to the
         model probability.
     """
-    from core.market_pricer import implied_prob
+    from core.market_pricer import implied_prob, calculate_ev_from_prob
 
     if p_market is None:
         p_market = implied_prob(market_odds)
@@ -169,6 +169,19 @@ def blend_prob(
         p_model = 0.3 * 0.5 + 0.7 * p_model  # shrink toward neutral (50%)
 
     p_blended = w_model * p_model + w_market * p_market
+
+    ev_percent = calculate_ev_from_prob(p_blended, market_odds)
+    if ev_percent >= 10.0:
+        from core.logger import get_logger
+        logger = get_logger(__name__)
+        logger.debug(
+            "High-EV bet: std_dev_books=%.3f line_volatility_factor=%.3f "
+            "confirmation_strength=%.3f final_model_weight=%.3f",
+            std_dev_books,
+            line_volatility_factor,
+            strength,
+            w_model,
+        )
 
     if os.getenv("BLEND_PROB_DEBUG"):
         from core.logger import get_logger

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -12,6 +12,7 @@ MIN_NEGATIVE_ODDS = -150
 from core.market_pricer import decimal_odds
 from core.confirmation_utils import required_market_move, book_agreement_score
 from core.skip_reasons import SkipReason
+from core.logger import get_logger
 
 
 from utils import (
@@ -149,6 +150,12 @@ def should_log_bet(
     new_bet["side"] = side  # ensure consistent formatting
     stake = new_bet["full_stake"]
     ev = new_bet["ev_percent"]
+
+    if DEBUG_MODE and ev >= 10.0 and stake >= 2.0:
+        logger = get_logger(__name__)
+        logger.debug(
+            f"High EV bet passed thresholds: EV={ev:.2f}%, Stake={stake:.2f}u"
+        )
 
     odds_value = None
     try:


### PR DESCRIPTION
## Summary
- log metrics for high EV bets inside `blend_prob`
- show debug message in `should_log_bet` when EV and stake thresholds are met

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce422e1a8832c9efb2016a9b79990