### PR TITLE
Prevent overlapping snapshot dispatch

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -415,7 +415,12 @@ if initial_odds:
     last_log_time = last_snapshot_time
     last_sim_time = last_snapshot_time
     run_logger(initial_odds)
-    run_unified_snapshot_and_dispatch(initial_odds)
+    if any(p["name"].startswith("dispatch_") for p in active_processes):
+        logger.info(
+            "🟡 Skipping snapshot dispatch – previous dispatch scripts still active."
+        )
+    else:
+        run_unified_snapshot_and_dispatch(initial_odds)
 
 start_time = time.time()
 loop_count = 0
@@ -464,7 +469,12 @@ while True:
             else:
                 last_snapshot_time = now
                 run_logger(odds_file)
-                run_unified_snapshot_and_dispatch(odds_file)
+                if any(p["name"].startswith("dispatch_") for p in active_processes):
+                    logger.info(
+                        "🟡 Skipping snapshot dispatch – previous dispatch scripts still active."
+                    )
+                else:
+                    run_unified_snapshot_and_dispatch(odds_file)
         last_log_time = now
         triggered_log = True
 

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -67,8 +67,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # Clamp EV range to 5%-20%
-    args.min_ev = max(5.0, args.min_ev)
+    # Clamp EV range to sensible bounds
+    args.min_ev = max(0.0, args.min_ev)
     args.max_ev = min(20.0, args.max_ev)
     if args.min_ev > args.max_ev:
         args.max_ev = args.min_ev

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -78,7 +78,7 @@ def is_best_book_row(row: dict) -> bool:
 
 def is_live_snapshot_row(row: dict) -> bool:
     """Return True if row qualifies for the live snapshot."""
-    return row.get("ev_percent", 0) >= 5.0
+    return row.get("ev_percent", 0) >= 3.0
 
 
 def is_personal_book_row(row: dict) -> bool:


### PR DESCRIPTION
## Summary
- skip snapshot dispatch if a previous dispatch subprocess is still running
- relax live snapshot EV threshold to 3%
- allow `dispatch_live_snapshot` to accept `--min-ev` below 5%

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9bcda70c832c96d6ff8ea1bdf8ba