### PR TITLE
Implement retry logic for Discord posts

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -11,6 +11,7 @@ import io
 import pandas as pd
 
 import requests
+from utils import post_with_retries
 
 try:
     import dataframe_image as dfi
@@ -492,14 +493,14 @@ def send_bet_snapshot_to_discord(
 
     files = {"file": ("snapshot.png", buf, "image/png")}
     try:
-        resp = requests.post(
+        resp = post_with_retries(
             webhook_url,
             data={"payload_json": json.dumps({"content": caption})},
             files=files,
             timeout=10,
         )
-        resp.raise_for_status()
-        print(f"✅ Snapshot sent: {df.shape[0]} bets dispatched")
+        if resp:
+            print(f"✅ Snapshot sent: {df.shape[0]} bets dispatched")
     except Exception as e:
         print(f"❌ Failed to send snapshot for {market_type}: {e}")
     finally:
@@ -518,7 +519,7 @@ def _send_table_text(df: pd.DataFrame, market_type: str, webhook_url: str) -> No
 
     message = f"{caption}\n```\n{table}\n```"
     try:
-        requests.post(webhook_url, json={"content": message}, timeout=10)
+        post_with_retries(webhook_url, json={"content": message}, timeout=10)
     except Exception as e:
         print(f"❌ Failed to send text snapshot for {market_type}: {e}")
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1103,3 +1103,5 @@ def normalize_team_abbr_to_name(abbr):
     for use with reliever depth charts or display purposes.
     """
     return TEAM_NAME_FROM_ABBR.get(abbr.upper(), abbr.upper())
+
+from .discord import post_with_retries

--- a/utils/discord.py
+++ b/utils/discord.py
@@ -1,0 +1,30 @@
+import time
+import requests
+from requests.exceptions import RequestException
+
+def post_with_retries(url: str, logger=None, attempts: int = 3, **kwargs):
+    """POST to a URL with retry logic.
+
+    Parameters
+    ----------
+    url : str
+        The webhook URL to post to.
+    logger : logging.Logger, optional
+        Logger for error messages.
+    attempts : int, optional
+        Number of attempts before giving up.
+    **kwargs :
+        Additional arguments passed to ``requests.post``.
+    """
+    for attempt in range(attempts):
+        try:
+            resp = requests.post(url, **kwargs)
+            if resp.status_code in (200, 204):
+                return resp
+        except RequestException as exc:
+            if logger:
+                logger.warning("Discord post attempt %d failed: %s", attempt + 1, exc)
+        time.sleep(2 ** attempt)
+    if logger:
+        logger.error("Failed to post to %s after %d attempts", url, attempts)
+    return None


### PR DESCRIPTION
## Summary
- add `post_with_retries` helper in `utils.discord`
- use retry logic in snapshot dispatch helpers
- wrap Discord posts in `cli/log_betting_evals` with retries
- expose helper via `utils.__init__`
- record logger configuration for each logged bet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecf35c90c832c99de639da0b6887c