### PR TITLE
Wrap CSV fields before writing

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1604,6 +1604,12 @@ def write_to_csv(
             )
 
         row_to_write = {k: row.get(k, "") for k in fieldnames}
+
+        # Wrap any problematic strings with quotes to avoid malformed CSV rows
+        for k, v in row_to_write.items():
+            if isinstance(v, str) and ("," in v or "\n" in v):
+                row_to_write[k] = f'"{v.replace("\"", "'")}"'
+
         writer.writerow(row_to_write)
         if config.VERBOSE_MODE:
             print(f"✅ Logged to CSV → {row['game_id']} | {row['market']} | {row['side']}")


### PR DESCRIPTION
## Summary
- guard against commas/newlines in CSV fields when writing betting evaluation rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee5d0db54832c97e272e071a6bf32