### PR TITLE
Improve empty CLV snapshot handling

### DIFF
--- a/core/time_utils.py
+++ b/core/time_utils.py
@@ -15,4 +15,5 @@ def compute_hours_to_game(game_start: datetime, now: Optional[datetime] = None) 
     """
     start_et = to_eastern(game_start)
     now_et = to_eastern(now or now_eastern())
-    return (start_et - now_et).total_seconds() / 3600
+    diff = (start_et - now_et).total_seconds() / 3600
+    return diff if diff >= 0 else 0.0


### PR DESCRIPTION
## Summary
- allow `build_snapshot_rows` to optionally return processing counts
- add `send_empty_clv_notice` helper and use it when no bets qualify
- send counts along with the notice and handle empty DataFrames gracefully
- clamp negative results in `compute_hours_to_game`
- test Discord fallback paths for CLV snapshots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8064e338832c83da899c284c047b