### PR TITLE
Enable fuzzy game id matching for CLV snapshot

### DIFF
--- a/tests/test_dispatch_clv_snapshot.py
+++ b/tests/test_dispatch_clv_snapshot.py
@@ -105,3 +105,14 @@ def test_send_snapshot_empty(monkeypatch):
     dcs.send_snapshot(df, "http://example.com", {})
 
     assert "No qualifying open bets" in sent.get("content", "")
+
+
+def test_fuzzy_game_id_match():
+    target = "2030-06-16-COL@WSH-T1845"
+    alt = "2030-06-16-COL@WSH-T1846"
+    rows = [_row(target, "h2h", "COL")]
+    odds = {alt: {"h2h": {"COL": {"consensus_prob": 0.55}}}}
+
+    result = build_snapshot_rows(rows, odds)
+
+    assert len(result) == 1


### PR DESCRIPTION
## Summary
- extend `build_snapshot_rows` to locate odds using a fuzzy game id match when an exact lookup fails
- add a regression test covering the fuzzy match logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f85b50340832ca7bee97e36b32c81