### PR TITLE
Fix timezone bug in parse_start_time

### DIFF
--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -33,6 +33,7 @@ from utils import (
     get_market_entry_with_alternate_fallback,
     convert_full_team_spread_to_odds_key,
     to_eastern,
+    EASTERN_TZ,
     now_eastern,
     TEAM_NAME_TO_ABBR,
     TEAM_ABBR_TO_NAME,
@@ -186,6 +187,8 @@ def parse_start_time(gid: str, odds_game: dict | None) -> datetime | None:
         if len(digits) == 4:
             try:
                 dt = datetime.strptime(f"{date} {digits}", "%Y-%m-%d %H%M")
+                # Treat game_id times as already in Eastern rather than UTC
+                dt = dt.replace(tzinfo=EASTERN_TZ)
             except Exception:
                 dt = None
     if dt is None and odds_game:


### PR DESCRIPTION
## Summary
- parse game_id start times as Eastern to avoid premature UTC conversion
- import `EASTERN_TZ` for use in `parse_start_time`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507505aee8832cbc3a46b4efc5b98a