### PR TITLE
Add Eastern parsing test for game_id times

### DIFF
--- a/tests/test_parse_start_time.py
+++ b/tests/test_parse_start_time.py
@@ -18,3 +18,11 @@ def test_parse_start_time_fallback_iso():
     dt = parse_start_time(gid, odds)
     assert dt.tzinfo == EASTERN_TZ
     assert dt.hour == 14 and dt.minute == 45
+
+
+def test_parse_start_time_handles_eastern_token():
+    """Game ID time tags should already be in Eastern time."""
+    gid = "2025-07-04-NYM@ATL-T1905"
+    dt = parse_start_time(gid, None)
+    assert dt.tzinfo == EASTERN_TZ
+    assert dt.hour == 19 and dt.minute == 5


### PR DESCRIPTION
## Summary
- verify `parse_start_time()` interprets game_id time tags as Eastern

## Testing
- `pytest -q tests/test_parse_start_time.py::test_parse_start_time_handles_eastern_token`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507fd94e78832cb1ddde55996e2033