### PR TITLE
Fix early bet time parsing

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -59,9 +59,11 @@ def _start_time_from_gid(game_id: str) -> datetime | None:
     if not date:
         return None
     if time_part.startswith("T"):
+        # Handle tokens like "T1845" or "T1845-DH1" by isolating the time digits
         raw = time_part.split("-")[0][1:]
+        digits = "".join(c for c in raw if c.isdigit())[:4]
         try:
-            dt = datetime.strptime(f"{date} {raw}", "%Y-%m-%d %H%M")
+            dt = datetime.strptime(f"{date} {digits}", "%Y-%m-%d %H%M")
             return dt.replace(tzinfo=EASTERN_TZ)
         except Exception:
             return None


### PR DESCRIPTION
## Summary
- ensure `monitor_early_bets` treats game_id times as Eastern timezone

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850843ab520832cb773a10d38898976