### PR TITLE
Handle naive ISO start times

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -22,7 +22,7 @@ from core.market_eval_tracker import (
 )
 from core.lock_utils import with_locked_file
 from core.skip_reasons import SkipReason
-from utils import safe_load_json, now_eastern, EASTERN_TZ, parse_game_id
+from utils import safe_load_json, now_eastern, EASTERN_TZ, parse_game_id, to_eastern
 from utils import canonical_game_id
 from utils.book_helpers import ensure_consensus_books
 import re
@@ -558,7 +558,7 @@ def generate_clean_summary_table(
     stake_mode="model",
 ):
     import pandas as pd
-    from datetime import datetime
+    from datetime import datetime, timezone
     import os
 
     # ✅ Apply same filters as send_discord_notification
@@ -1715,6 +1715,9 @@ def log_bets(
         if start_str:
             try:
                 start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+                if start_dt.tzinfo is None:
+                    start_dt = start_dt.replace(tzinfo=timezone.utc)
+                start_dt = to_eastern(start_dt)
             except Exception:
                 logger.warning("❌ Failed to parse start time %s", start_str)
         if not start_dt:
@@ -1950,7 +1953,7 @@ def log_derivative_bets(
     skipped_bets=None,
     existing=None,
 ):
-    from datetime import datetime
+    from datetime import datetime, timezone
     from core.market_pricer import decimal_odds, implied_prob, kelly_fraction
     from utils import convert_full_team_spread_to_odds_key
 
@@ -1968,6 +1971,9 @@ def log_derivative_bets(
         if start_str:
             try:
                 start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+                if start_dt.tzinfo is None:
+                    start_dt = start_dt.replace(tzinfo=timezone.utc)
+                start_dt = to_eastern(start_dt)
             except Exception:
                 logger.warning("❌ Failed to parse start time %s", start_str)
         if not start_dt:

--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -15,7 +15,7 @@ import json
 import csv
 import io
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import requests
@@ -199,6 +199,9 @@ def parse_start_time(gid: str, odds_game: dict | None) -> datetime | None:
         if start_iso:
             try:
                 dt = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                dt = to_eastern(dt)
             except Exception:
                 dt = None
     return to_eastern(dt) if dt else None

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -2,7 +2,7 @@
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 from typing import List, Dict, Tuple
 from typing import Optional
@@ -724,6 +724,9 @@ def build_snapshot_rows(
         if start_str:
             try:
                 dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                dt = to_eastern(dt)
                 hours_to_game = compute_hours_to_game(dt)
                 logger.debug(
                     "🕓 %s start=%s now=%s Δ=%.2fh",


### PR DESCRIPTION
## Summary
- normalize start times that lack timezone info
- import timezone helpers
- convert odds API times from UTC to Eastern when missing tzinfo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850854b5c18832cb02486aba84671ca