### PR TITLE
Add timezone check for parse_start_time

### DIFF
--- a/tests/test_parse_start_time.py
+++ b/tests/test_parse_start_time.py
@@ -26,3 +26,12 @@ def test_parse_start_time_handles_eastern_token():
     dt = parse_start_time(gid, None)
     assert dt.tzinfo == EASTERN_TZ
     assert dt.hour == 19 and dt.minute == 5
+
+
+def test_parse_start_time_returns_eastern():
+    """Game ID times should parse directly to Eastern timezone."""
+    gid = "2025-06-16-COL@WSH-T1905"
+    dt = parse_start_time(gid, None)
+    zone_name = getattr(dt.tzinfo, "zone", getattr(dt.tzinfo, "key", None))
+    assert zone_name == "US/Eastern"
+    assert dt.hour == 19 and dt.minute == 5


### PR DESCRIPTION
## Summary
- add test ensuring parse_start_time interprets game id times as Eastern

## Testing
- `pytest -k parse_start_time -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685086e919e4832c8cae2fd158ae9032