### PR TITLE
Ensure snapshot filename timestamps use Eastern TZ

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -22,7 +22,14 @@ from core.market_eval_tracker import (
 )
 from core.lock_utils import with_locked_file
 from core.skip_reasons import SkipReason
-from utils import safe_load_json, now_eastern, EASTERN_TZ, parse_game_id, to_eastern
+from utils import (
+    safe_load_json,
+    now_eastern,
+    EASTERN_TZ,
+    parse_game_id,
+    to_eastern,
+    parse_snapshot_timestamp,
+)
 from utils import canonical_game_id
 from core.dispatch_clv_snapshot import parse_start_time
 from utils.book_helpers import ensure_consensus_books
@@ -206,15 +213,11 @@ if SNAPSHOT_PATH_USED and os.path.exists(SNAPSHOT_PATH_USED):
     # Determine snapshot timestamp from filename or modification time
     snap_dt = None
     m = re.search(
-        r"market_snapshot_(\d{8}T\d{4})", os.path.basename(SNAPSHOT_PATH_USED)
+        r"market_snapshot_(\d{8}T\d{4})",
+        os.path.basename(SNAPSHOT_PATH_USED),
     )
     if m:
-        try:
-            snap_dt = datetime.strptime(m.group(1), "%Y%m%dT%H%M").replace(
-                tzinfo=EASTERN_TZ
-            )
-        except Exception:
-            snap_dt = None
+        snap_dt = parse_snapshot_timestamp(m.group(1))
     if snap_dt is None:
         try:
             snap_dt = datetime.fromtimestamp(

--- a/tests/test_snapshot_timestamp.py
+++ b/tests/test_snapshot_timestamp.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import parse_snapshot_timestamp, EASTERN_TZ
+
+
+def test_parse_snapshot_timestamp_basic():
+    dt = parse_snapshot_timestamp("20250616T1530")
+    assert dt.tzinfo == EASTERN_TZ
+    assert dt.hour == 15 and dt.minute == 30

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1013,6 +1013,18 @@ def game_id_to_dt(game_id: str) -> datetime | None:
     return dt.replace(tzinfo=EASTERN_TZ) if dt else None
 
 
+def parse_snapshot_timestamp(token: str) -> datetime | None:
+    """Return Eastern-aware datetime from ``YYYYMMDDTHHMM`` string."""
+    try:
+        dt = datetime.strptime(token, "%Y%m%dT%H%M")
+        try:  # pytz compatibility
+            return EASTERN_TZ.localize(dt)
+        except AttributeError:
+            return dt.replace(tzinfo=EASTERN_TZ)
+    except Exception:
+        return None
+
+
 def lookup_fallback_odds(game_id: str, fallback_odds: dict) -> dict | None:
     """Return the best-matching fallback odds entry for ``game_id``."""
     if not isinstance(fallback_odds, dict):


### PR DESCRIPTION
## Summary
- add `parse_snapshot_timestamp` utility to parse filename timestamps
- apply new helper in `log_betting_evals`
- test timestamp parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508b5175d4832c80e2095d0fc763d9