### PR TITLE
Fix start-time filtering checks

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1734,7 +1734,7 @@ def log_bets(
     if start_dt:
         hours_to_game = compute_hours_to_game(start_dt)
 
-    if hours_to_game < 0:
+    if hours_to_game <= 0:
         print(
             f"⏱️ Skipping {game_id} — game has already started ({hours_to_game:.2f}h ago)"
         )
@@ -1992,7 +1992,7 @@ def log_derivative_bets(
     if start_dt:
         hours_to_game = compute_hours_to_game(start_dt)
 
-    if hours_to_game < 0:
+    if hours_to_game <= 0:
         print(
             f"⏱️ Skipping {game_id} — game has already started ({hours_to_game:.2f}h ago)"
         )

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -749,7 +749,7 @@ def build_snapshot_rows(
                 start_formatted = start_et.strftime("%-I:%M %p")
             except Exception:
                 start_formatted = start_et.strftime("%I:%M %p").lstrip("0")
-        if hours_to_game < 0:
+        if hours_to_game <= 0:
             logger.debug(
                 "⏱️ Skipping %s — game has already started (%.2fh ago)",
                 game_id,


### PR DESCRIPTION
## Summary
- ensure post-start logic excludes bets at start time
- update snapshot filter for game start
- adjust full pipeline test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b36906b4832ca5d966cc76b45432