### PR TITLE
Fix snapshot loading errors

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -38,7 +38,7 @@ def load_rows(path: str) -> list:
     rows = safe_load_json(path)
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
-        return []
+        sys.exit(1)
     return rows
 
 
@@ -84,7 +84,7 @@ def main() -> None:
     path = args.snapshot_path or latest_snapshot_path()
     if not path or not os.path.exists(path):
         logger.error("❌ Snapshot not found: %s", path)
-        return
+        sys.exit(1)
 
     rows = load_rows(path)
     for r in rows:

--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -163,9 +163,13 @@ def get_market_data_with_alternates(consensus_odds, market_key):
 def load_logged_bets(path: str) -> list:
     if not os.path.exists(path):
         logger.error("❌ Logged bets CSV not found: %s", path)
-        return []
-    with open(path, newline="") as f:
-        return list(csv.DictReader(f))
+        sys.exit(1)
+    try:
+        with open(path, newline="") as f:
+            return list(csv.DictReader(f))
+    except Exception as e:
+        logger.error("❌ Failed to load logged bets CSV %s: %s", path, e)
+        sys.exit(1)
 
 
 def load_odds(path: str) -> dict:
@@ -174,7 +178,7 @@ def load_odds(path: str) -> dict:
             return json.load(f)
     except Exception as e:
         logger.error("❌ Failed to load odds file %s: %s", path, e)
-        return {}
+        sys.exit(1)
 
 
 def parse_start_time(gid: str, odds_game: dict | None) -> datetime | None:
@@ -510,7 +514,7 @@ def main() -> None:
     odds_path = args.odds_path or latest_odds_file()
     if not odds_path or not os.path.exists(odds_path):
         logger.error("❌ Odds snapshot not found: %s", odds_path)
-        return
+        sys.exit(1)
     odds_data = load_odds(odds_path)
 
     rows, counts = build_snapshot_rows(

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -40,7 +40,7 @@ def load_rows(path: str) -> list:
     rows = safe_load_json(path)
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
-        return []
+        sys.exit(1)
     return rows
 
 
@@ -115,7 +115,7 @@ def main() -> None:
     path = args.snapshot_path or latest_snapshot_path()
     if not path or not os.path.exists(path):
         logger.error("❌ Snapshot not found: %s", path)
-        return
+        sys.exit(1)
 
     rows = load_rows(path)
     for r in rows:

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -36,7 +36,7 @@ def load_rows(path: str) -> list:
     rows = safe_load_json(path)
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
-        return []
+        sys.exit(1)
     return rows
 
 
@@ -76,7 +76,7 @@ def main() -> None:
     path = args.snapshot_path or latest_snapshot_path()
     if not path or not os.path.exists(path):
         logger.error("❌ Snapshot not found: %s", path)
-        return
+        sys.exit(1)
 
     rows = load_rows(path)
     for r in rows:

--- a/core/dispatch_sim_only_snapshot.py
+++ b/core/dispatch_sim_only_snapshot.py
@@ -52,7 +52,7 @@ def load_rows(path: str) -> List[dict]:
     rows = safe_load_json(path)
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
-        return []
+        sys.exit(1)
     return rows
 
 
@@ -178,7 +178,7 @@ def main() -> None:
     path = args.snapshot_path or latest_snapshot_path()
     if not path or not os.path.exists(path):
         logger.error("❌ Snapshot not found: %s", path)
-        return
+        sys.exit(1)
 
     rows = load_rows(path)
     rows = filter_by_date(rows, args.date)


### PR DESCRIPTION
## Summary
- ensure dispatch scripts terminate if the snapshot can't be loaded
- update snapshot checks for live, best book, FV drop, CLV and sim-only dispatchers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68514ecf57bc832cb98ad2f12007b2b9