### PR TITLE
Handle missing CSV stakes in should_log_bet

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -2652,6 +2652,7 @@ def process_theme_logged_bets(
                     verbose=config.VERBOSE_MODE,
                     eval_tracker=MARKET_EVAL_TRACKER,
                     reference_tracker=MARKET_EVAL_TRACKER_BEFORE_UPDATE,
+                    existing_csv_stakes=existing,
                 )
 
                 if not evaluated:

--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -132,6 +132,7 @@ def recheck_pending_bets(path: str = PENDING_BETS_PATH) -> None:
             verbose=False,
             eval_tracker=eval_tracker,
             reference_tracker=ref,
+            existing_csv_stakes=existing,
         )
         if evaluated:
             result = write_to_csv(


### PR DESCRIPTION
## Summary
- allow should_log_bet to see existing CSV stakes
- handle missing stake case when calculating delta
- pass existing_csv_stakes in CLI modules
- adjust top-up tests for coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685175784274832c8e1829111741893f