### PR TITLE
Fix best_book fallback logic

### DIFF
--- a/core/book_whitelist.py
+++ b/core/book_whitelist.py
@@ -1,0 +1,18 @@
+ALLOWED_BOOKS = [
+    "betonlineag",
+    "betus",
+    "bovada",
+    "williamhill_us",
+    "draftkings",
+    "fanduel",
+    "fanatics",
+    "betmgm",
+    "betrivers",
+    "ballybet",
+    "espnbet",
+    "fliff",
+    "mybookieag",
+    "pinnacle",
+    "novig",
+    "prophetx",
+]


### PR DESCRIPTION
## Summary
- centralize allowed sportsbook list in `core/book_whitelist.py`
- import `ALLOWED_BOOKS` in `log_betting_evals.py`
- fall back to an approved book when `best_book` is not allowed
- skip bets without any approved sportsbook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853fc858dd4832cada9b19624a7d238