### PR TITLE
Centralize allowed books list

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -33,6 +33,7 @@ from utils import (
 from utils import canonical_game_id
 from core.dispatch_clv_snapshot import parse_start_time
 from utils.book_helpers import ensure_consensus_books
+from core.book_whitelist import ALLOWED_BOOKS
 import re
 import warnings
 
@@ -414,24 +415,7 @@ BOOKMAKER_TO_ROLE = {
 }
 
 # Book list aligned with ODDS_FETCHER Issue 1 updates
-POPULAR_BOOKS = [
-    "betonlineag",
-    "betus",
-    "bovada",
-    "williamhill_us",
-    "draftkings",
-    "fanduel",
-    "fanatics",
-    "betmgm",
-    "betrivers",
-    "ballybet",
-    "espnbet",
-    "fliff",
-    "mybookieag",
-    "pinnacle",
-    "novig",
-    "prophetx",
-]
+POPULAR_BOOKS = list(ALLOWED_BOOKS)
 
 # === Segment Label to Discord Role Mapping (placeholder IDs) ===
 SEGMENT_ROLE = {

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -21,6 +21,7 @@ from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
 from core.should_log_bet import MAX_POSITIVE_ODDS, MIN_NEGATIVE_ODDS
 from utils.book_helpers import parse_american_odds, filter_by_odds
+from core.book_whitelist import ALLOWED_BOOKS
 
 logger = get_logger(__name__)
 
@@ -158,24 +159,7 @@ def main() -> None:
     df_all_books = df.copy()
 
     # ✅ Hardcoded sportsbook filter for FV Drop (aligned with POPULAR_BOOKS)
-    allowed_books = [
-        "betonlineag",
-        "betus",
-        "bovada",
-        "williamhill_us",
-        "draftkings",
-        "fanduel",
-        "fanatics",
-        "betmgm",
-        "betrivers",
-        "ballybet",
-        "espnbet",
-        "fliff",
-        "mybookieag",
-        "pinnacle",
-        "novig",
-        "prophetx",
-    ]
+    allowed_books = list(ALLOWED_BOOKS)
 
     df_allowed = filter_by_books(df, allowed_books)
     df_allowed = filter_main_lines(df_allowed)

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -18,6 +18,7 @@ load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
+from core.book_whitelist import ALLOWED_BOOKS
 
 logger = get_logger(__name__)
 
@@ -112,24 +113,7 @@ def main() -> None:
     )
 
     df = format_for_display(rows, include_movement=True)
-    allowed_books = [
-        "betonlineag",
-        "betus",
-        "bovada",
-        "williamhill_us",
-        "draftkings",
-        "fanduel",
-        "fanatics",
-        "betmgm",
-        "betrivers",
-        "ballybet",
-        "espnbet",
-        "fliff",
-        "mybookieag",
-        "pinnacle",
-        "novig",
-        "prophetx",
-    ]
+    allowed_books = list(ALLOWED_BOOKS)
     df = filter_by_books(df, allowed_books)
     if "sim_prob_display" in df.columns:
         df["Sim %"] = df["sim_prob_display"]

--- a/core/odds_fetcher.py
+++ b/core/odds_fetcher.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 
 from core.market_pricer import implied_prob, to_american_odds, best_price
 from core.bookmakers import get_us_bookmakers
+from core.book_whitelist import ALLOWED_BOOKS
 from utils import (
     normalize_label,
     normalize_label_for_odds,
@@ -33,12 +34,7 @@ load_dotenv()
 ODDS_API_KEY = os.getenv("ODDS_API_KEY")
 SPORT = "baseball_mlb"
 
-BOOKMAKERS = [
-    "betonlineag", "betus", "bovada", "williamhill_us",
-    "draftkings", "fanduel", "fanatics", "betmgm",
-    "betrivers", "ballybet", "espnbet", "fliff",
-    "mybookieag", "pinnacle", "novig", "prophetx",
-]
+BOOKMAKERS = sorted(ALLOWED_BOOKS)
 from core.logger import get_logger
 
 logger = get_logger(__name__)

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -19,6 +19,7 @@ from core.bootstrap import *  # noqa
 from utils import now_eastern, safe_load_json, lookup_fallback_odds
 from core.logger import get_logger
 from core.odds_fetcher import fetch_market_odds_from_api
+from core.book_whitelist import ALLOWED_BOOKS
 from core.snapshot_core import (
     load_simulations,
     build_snapshot_rows as _core_build_snapshot_rows,
@@ -55,24 +56,7 @@ def latest_odds_file(folder="data/market_odds") -> str | None:
 # Snapshot role helpers
 # ---------------------------------------------------------------------------
 # Book list aligned with ODDS_FETCHER Issue 1 updates
-POPULAR_BOOKS = [
-    "betonlineag",
-    "betus",
-    "bovada",
-    "williamhill_us",
-    "draftkings",
-    "fanduel",
-    "fanatics",
-    "betmgm",
-    "betrivers",
-    "ballybet",
-    "espnbet",
-    "fliff",
-    "mybookieag",
-    "pinnacle",
-    "novig",
-    "prophetx",
-]
+POPULAR_BOOKS = list(ALLOWED_BOOKS)
 
 
 def is_best_book_row(row: dict) -> bool:


### PR DESCRIPTION
## Summary
- load ALLOWED_BOOKS from `core.book_whitelist` across the codebase
- remove duplicate sportsbook lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540136c1fc832cb4156c9cb19d5e21