### PR TITLE
Deprecate legacy book utils

### DIFF
--- a/core/bookmakers.py
+++ b/core/bookmakers.py
@@ -93,21 +93,19 @@ BOOKMAKER_CATALOG = {
     }
 }
 
-def get_us_bookmakers(include_exchanges=False, include_dfs=False, include_secondary=False):
-    keys = list(BOOKMAKER_CATALOG["us"].keys())
-    if include_secondary:
-        keys += BOOKMAKER_CATALOG["us2"].keys()
-    if include_exchanges:
-        keys += BOOKMAKER_CATALOG["us_ex"].keys()
-    if include_dfs:
-        keys += BOOKMAKER_CATALOG["us_dfs"].keys()
-    return keys
+# Import deprecated helpers for backwards compatibility.
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+from .legacy_book_utils import get_us_bookmakers  # noqa: F401
 
-def get_all_bookmaker_keys():
-    return [key for region in BOOKMAKER_CATALOG.values() for key in region.keys()]
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+from .legacy_book_utils import get_all_bookmaker_keys  # noqa: F401
 
-def get_bookmaker_label(book_key):
-    for region in BOOKMAKER_CATALOG.values():
-        if book_key in region:
-            return region[book_key]
-    return book_key  # fallback to key if not found
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+from .legacy_book_utils import get_all_bookmaker_display_names  # noqa: F401
+
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+from .legacy_book_utils import get_bookmaker_label  # noqa: F401

--- a/core/legacy_book_utils.py
+++ b/core/legacy_book_utils.py
@@ -1,0 +1,66 @@
+# Legacy bookmaker utilities
+"""Deprecated utilities for retrieving bookmaker sets and labels.
+
+These helpers were superseded by :mod:`core.book_whitelist` and are kept
+only for backward compatibility.
+"""
+
+from warnings import warn
+
+from .bookmakers import BOOKMAKER_CATALOG
+
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+def get_us_bookmakers(include_exchanges: bool = False,
+                      include_dfs: bool = False,
+                      include_secondary: bool = False):
+    """Return US bookmakers optionally including exchanges/DFS providers."""
+    warn(
+        "get_us_bookmakers is deprecated; use book_whitelist.ALLOWED_BOOKS",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    keys = list(BOOKMAKER_CATALOG["us"].keys())
+    if include_secondary:
+        keys += BOOKMAKER_CATALOG["us2"].keys()
+    if include_exchanges:
+        keys += BOOKMAKER_CATALOG["us_ex"].keys()
+    if include_dfs:
+        keys += BOOKMAKER_CATALOG["us_dfs"].keys()
+    return list(keys)
+
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+def get_all_bookmaker_keys():
+    """Return all bookmaker keys across regions."""
+    warn(
+        "get_all_bookmaker_keys is deprecated; use book_whitelist.ALLOWED_BOOKS",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return [key for region in BOOKMAKER_CATALOG.values() for key in region.keys()]
+
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+def get_all_bookmaker_display_names():
+    """Return display names for all known bookmakers."""
+    warn(
+        "get_all_bookmaker_display_names is deprecated; use book_whitelist.ALLOWED_BOOKS",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return [label for region in BOOKMAKER_CATALOG.values() for label in region.values()]
+
+# ⚠️ Deprecated – not used in current logging/snapshot logic.
+# Logic now relies on core.book_whitelist.ALLOWED_BOOKS.
+def get_bookmaker_label(book_key: str):
+    """Return a display label for ``book_key`` if known."""
+    warn(
+        "get_bookmaker_label is deprecated; use book_whitelist.ALLOWED_BOOKS",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    for region in BOOKMAKER_CATALOG.values():
+        if book_key in region:
+            return region[book_key]
+    return book_key

--- a/core/odds_fetcher.py
+++ b/core/odds_fetcher.py
@@ -12,7 +12,6 @@ from zoneinfo import ZoneInfo
 from collections import defaultdict
 
 from core.market_pricer import implied_prob, to_american_odds, best_price
-from core.bookmakers import get_us_bookmakers
 from core.book_whitelist import ALLOWED_BOOKS
 from utils import (
     normalize_label,


### PR DESCRIPTION
## Summary
- move old bookmaker helpers to `legacy_book_utils`
- mark helpers as deprecated inside `bookmakers`
- stop importing deprecated helpers in `odds_fetcher`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685405ea6274832c9596571556a6fd8f