### PR TITLE
Fix side propagation in snapshot rows

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -156,6 +156,10 @@ def build_snapshot_for_date(
                 ):
                     best_book_tracker[key] = row
 
+        # ✅ Normalize 'side' from nested 'bet' if not already present
+        if "side" not in row and isinstance(row.get("bet"), dict):
+            row["side"] = row["bet"].get("side")
+
         snapshot_rows.append(row)
 
     for best_row in best_book_tracker.values():


### PR DESCRIPTION
## Summary
- normalize `side` field from nested bet dictionary when missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540a5f08c4832cb1d6c51130611782