### PR TITLE
Centralize side normalization

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -793,9 +793,6 @@ def expand_snapshot_rows_with_kelly(
     expanded_rows = []
 
     for bet in final_snapshot:
-        # Defensive fallback for missing 'side'
-        if "side" not in bet and isinstance(bet.get("bet"), dict):
-            bet["side"] = bet["bet"].get("side")
         # ✅ Normalize market_prob from consensus_prob if not already present
         if "market_prob" not in bet and "consensus_prob" in bet:
             bet["market_prob"] = bet["consensus_prob"]
@@ -952,9 +949,6 @@ def expand_snapshot_rows_with_kelly(
     seen = set()
     deduped = []
     for row in expanded_rows:
-        # Defensive fallback for missing 'side'
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
         key = (row["game_id"], row["market"], row["side"], row["best_book"])
         if key not in seen:
             deduped.append(row)
@@ -999,9 +993,6 @@ def get_theme(row):
     - Match full team names (handles New York teams correctly)
     - Over/Under bets separately
     """
-    # Defensive fallback for missing 'side'
-    if "side" not in row and isinstance(row.get("bet"), dict):
-        row["side"] = row["bet"].get("side")
     side = remap_side_key(row["side"])  # Normalize side first
     market = row["market"]
 
@@ -1464,9 +1455,6 @@ def send_discord_notification(row, skipped_bets=None):
 
 
 def get_exposure_key(row):
-    # Defensive fallback for missing 'side'
-    if "side" not in row and isinstance(row.get("bet"), dict):
-        row["side"] = row["bet"].get("side")
     market = row["market"]
     game_id = row["game_id"]
     side = remap_side_key(row["side"])
@@ -1526,9 +1514,6 @@ def write_to_csv(
         updates the provided dict. Persisting the updated exposure data is
         handled by the caller.
     """
-    # Defensive fallback for missing 'side'
-    if "side" not in row and isinstance(row.get("bet"), dict):
-        row["side"] = row["bet"].get("side")
     if not row.get("side") or float(row.get("stake", 0.0)) <= 0.0 or row.get("skip_reason"):
         logger.warning(
             "⛔ Skipping tracker update due to invalid or zero-stake bet: %s",
@@ -2787,9 +2772,6 @@ def run_batch_logging(
     theme_logged = defaultdict(lambda: defaultdict(dict))
 
     def cache_theme_bet(row, segment):
-        # Defensive fallback for missing 'side'
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
         theme = get_theme(row)
         game_id = row["game_id"]
         market = row["market"]
@@ -2942,9 +2924,6 @@ def process_theme_logged_bets(
                 key=lambda x: 1 if x[1].get("market_class") == "alternate" else 0
             )
             for segment, row in ordered_rows:
-                # Defensive fallback for missing 'side'
-                if "side" not in row and isinstance(row.get("bet"), dict):
-                    row["side"] = row["bet"].get("side")
                 stake = round(float(row.get("full_stake", row.get("stake", 0))), 2)
                 ev = row.get("ev_percent", 0)
                 print(
@@ -2959,9 +2938,6 @@ def process_theme_logged_bets(
                 key=lambda x: 1 if x[1].get("market_class") == "alternate" else 0
             )
             for segment, row in ordered_rows:
-                # Defensive fallback for missing 'side'
-                if "side" not in row and isinstance(row.get("bet"), dict):
-                    row["side"] = row["bet"].get("side")
                 proposed_stake = round(float(row.get("full_stake", 0)), 2)
                 key = (row["game_id"], row["market"], row["side"])
                 line_key = (row["market"], row["side"])
@@ -3090,9 +3066,6 @@ def process_theme_logged_bets(
     final_rows = []
     failed_log_count = 0
     for best_row in best_market_segment.values():
-        # ✅ Ensure 'side' is present for CSV logging and Discord output
-        if "side" not in best_row and isinstance(best_row.get("bet"), dict):
-            best_row["side"] = best_row["bet"].get("side")
         if config.VERBOSE_MODE:
             print(
                 f"📄 Logging: {best_row['game_id']} | {best_row['market']} | {best_row['side']} @ {best_row['stake']}u"

--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
-from utils.book_helpers import filter_snapshot_rows
+from utils.book_helpers import filter_snapshot_rows, ensure_side
 from core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -39,6 +39,8 @@ def load_rows(path: str) -> list:
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
         sys.exit(1)
+    for r in rows:
+        ensure_side(r)
     return rows
 
 
@@ -91,10 +93,6 @@ def main() -> None:
         if "book" not in r and "best_book" in r:
             r["book"] = r["best_book"]
 
-    # Ensure 'side' is present for downstream filtering and display
-    for row in rows:
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
     rows = [r for r in rows if "best_book" in r.get("snapshot_roles", [])]
     rows = filter_by_date(rows, args.date)
 

--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -42,7 +42,7 @@ from utils import (
 from core.logger import get_logger
 from core.odds_fetcher import american_to_prob
 from core.market_pricer import calculate_clv_and_fv
-from utils.book_helpers import filter_snapshot_rows
+from utils.book_helpers import filter_snapshot_rows, ensure_side
 
 try:
     import dataframe_image as dfi
@@ -523,11 +523,8 @@ def main() -> None:
     rows, counts = build_snapshot_rows(
         csv_rows, odds_data, verbose=args.verbose, return_counts=True
     )
-
-    # Ensure 'side' is present for downstream filtering and display
     for row in rows:
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
+        ensure_side(row)
 
     # rows = filter_snapshot_rows(rows)
 

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -20,7 +20,7 @@ load_dotenv()
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
 from core.should_log_bet import MAX_POSITIVE_ODDS, MIN_NEGATIVE_ODDS
-from utils.book_helpers import parse_american_odds, filter_by_odds
+from utils.book_helpers import parse_american_odds, filter_by_odds, ensure_side
 from core.book_whitelist import ALLOWED_BOOKS
 
 logger = get_logger(__name__)
@@ -42,6 +42,8 @@ def load_rows(path: str) -> list:
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
         sys.exit(1)
+    for r in rows:
+        ensure_side(r)
     return rows
 
 
@@ -123,10 +125,6 @@ def main() -> None:
         if "book" not in r and "best_book" in r:
             r["book"] = r["best_book"]
 
-    # Ensure 'side' is present for downstream filtering and display
-    for row in rows:
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
 
     # ✅ No role/movement filter — allow full snapshot set
     rows = filter_by_date(rows, args.date)

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
-from utils.book_helpers import filter_snapshot_rows
+from utils.book_helpers import filter_snapshot_rows, ensure_side
 from core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -37,6 +37,8 @@ def load_rows(path: str) -> list:
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
         sys.exit(1)
+    for r in rows:
+        ensure_side(r)
     return rows
 
 
@@ -83,10 +85,6 @@ def main() -> None:
         if "book" not in r and "best_book" in r:
             r["book"] = r["best_book"]
 
-    # Ensure 'side' is present for downstream filtering and display
-    for row in rows:
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
     rows = [r for r in rows if "live" in r.get("snapshot_roles", [])]
     rows = filter_by_date(rows, args.date)
 

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -19,6 +19,7 @@ load_dotenv()
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
 from core.book_whitelist import ALLOWED_BOOKS
+from utils.book_helpers import ensure_side
 
 logger = get_logger(__name__)
 
@@ -44,6 +45,8 @@ def load_rows(path: str) -> list:
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
         return []
+    for r in rows:
+        ensure_side(r)
     return rows
 
 
@@ -98,10 +101,6 @@ def main() -> None:
         if "book" not in r and "best_book" in r:
             r["book"] = r["best_book"]
 
-    # Ensure 'side' is present for downstream filtering and display
-    for row in rows:
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
     rows = [r for r in rows if "personal" in r.get("snapshot_roles", [])]
     rows = filter_by_date(rows, args.date)
 

--- a/core/dispatch_sim_only_snapshot.py
+++ b/core/dispatch_sim_only_snapshot.py
@@ -16,6 +16,7 @@ import requests
 from requests.exceptions import Timeout
 
 from utils import safe_load_json, post_with_retries
+from utils.book_helpers import ensure_side
 from core.logger import get_logger
 from core.market_pricer import (
     extract_best_book,
@@ -53,6 +54,8 @@ def load_rows(path: str) -> List[dict]:
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
         sys.exit(1)
+    for r in rows:
+        ensure_side(r)
     return rows
 
 
@@ -182,10 +185,6 @@ def main() -> None:
 
     rows = load_rows(path)
 
-    # Ensure 'side' is present for downstream filtering and display
-    for row in rows:
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
 
     rows = filter_by_date(rows, args.date)
 

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -156,10 +156,6 @@ def build_snapshot_for_date(
                 ):
                     best_book_tracker[key] = row
 
-        # Defensive normalization of 'side'
-        if "side" not in row and isinstance(row.get("bet"), dict):
-            row["side"] = row["bet"].get("side")
-
         snapshot_rows.append(row)
 
     for best_row in best_book_tracker.values():

--- a/utils/book_helpers.py
+++ b/utils/book_helpers.py
@@ -87,3 +87,10 @@ def ensure_consensus_books(row: Dict) -> None:
             row["consensus_books"] = row["_raw_sportsbook"]
         elif isinstance(row.get("best_book"), str) and isinstance(row.get("market_odds"), (int, float)):
             row["consensus_books"] = {row["best_book"]: row["market_odds"]}
+
+
+def ensure_side(row: Dict) -> None:
+    """Promote ``row['bet']['side']`` to ``row['side']`` when present."""
+    if "side" not in row and isinstance(row.get("bet"), dict):
+        row["side"] = row["bet"].get("side")
+


### PR DESCRIPTION
## Summary
- add `ensure_side` helper and use it in snapshot dispatchers
- remove legacy `side` fallback logic
- drop redundant normalization in `unified_snapshot_generator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854237cdcbc832ca20f53aa0cac45cb