### PR TITLE
Fix dispatch imports

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -7,7 +7,7 @@ from core.bootstrap import *  # noqa
 """Dispatch best-book snapshot from unified snapshot JSON."""
 
 import json
-from utils import safe_load_json
+from core.utils import safe_load_json
 import argparse
 from dotenv import load_dotenv
 
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
-from utils.book_helpers import filter_snapshot_rows, ensure_side
+from core.utils.book_helpers import filter_snapshot_rows, ensure_side
 from core.logger import get_logger
 
 logger = get_logger(__name__)

--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -23,7 +23,7 @@ from requests.exceptions import Timeout
 from dotenv import load_dotenv
 from core.bootstrap import *  # noqa
 
-from utils import (
+from core.utils import (
     parse_game_id,
     canonical_game_id,
     normalize_line_label,
@@ -42,7 +42,7 @@ from utils import (
 from core.logger import get_logger
 from core.odds_fetcher import american_to_prob
 from core.market_pricer import calculate_clv_and_fv
-from utils.book_helpers import filter_snapshot_rows, ensure_side
+from core.utils.book_helpers import filter_snapshot_rows, ensure_side
 
 try:
     import dataframe_image as dfi

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -7,7 +7,7 @@ from core.bootstrap import *  # noqa
 """Dispatch FV drop snapshot (market probability increases) from unified snapshot JSON."""
 
 import json
-from utils import safe_load_json
+from core.utils import safe_load_json
 import argparse
 from typing import List
 import re
@@ -20,7 +20,7 @@ load_dotenv()
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
 from core.should_log_bet import MAX_POSITIVE_ODDS, MIN_NEGATIVE_ODDS
-from utils.book_helpers import parse_american_odds, filter_by_odds, ensure_side
+from core.utils.book_helpers import parse_american_odds, filter_by_odds, ensure_side
 from core.book_whitelist import ALLOWED_BOOKS
 
 logger = get_logger(__name__)

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -7,7 +7,7 @@ from core.bootstrap import *  # noqa
 """Dispatch live snapshot from unified snapshot JSON."""
 
 import json
-from utils import safe_load_json
+from core.utils import safe_load_json
 import argparse
 from dotenv import load_dotenv
 
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
-from utils.book_helpers import filter_snapshot_rows, ensure_side
+from core.utils.book_helpers import filter_snapshot_rows, ensure_side
 from core.logger import get_logger
 
 logger = get_logger(__name__)

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -7,7 +7,7 @@ from core.bootstrap import *  # noqa
 """Dispatch personal-book snapshot from unified snapshot JSON."""
 
 import json
-from utils import safe_load_json
+from core.utils import safe_load_json
 import argparse
 from typing import List
 import pandas as pd
@@ -19,7 +19,7 @@ load_dotenv()
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
 from core.book_whitelist import ALLOWED_BOOKS
-from utils.book_helpers import ensure_side
+from core.utils.book_helpers import ensure_side
 
 logger = get_logger(__name__)
 

--- a/core/dispatch_sim_only_snapshot.py
+++ b/core/dispatch_sim_only_snapshot.py
@@ -15,8 +15,8 @@ import pandas as pd
 import requests
 from requests.exceptions import Timeout
 
-from utils import safe_load_json, post_with_retries
-from utils.book_helpers import ensure_side
+from core.utils import safe_load_json, post_with_retries
+from core.utils.book_helpers import ensure_side
 from core.logger import get_logger
 from core.market_pricer import (
     extract_best_book,


### PR DESCRIPTION
## Summary
- fix broken imports in dispatch scripts

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'parse_game_id' from 'core.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68542dc47688832c945169a5fae46f6d