### PR TITLE
Fix .env webhook key for personal snapshot

### DIFF
--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -24,10 +24,10 @@ from core.book_helpers import ensure_side
 logger = get_logger(__name__)
 
 # Optional debug log to verify environment variables are loaded
-logger.debug("✅ Loaded webhook: %s", os.getenv("DISCORD_PERSONAL_WEBHOOK_URL"))
+logger.debug("✅ Loaded webhook: %s", os.getenv("PERSONAL_DISCORD_WEBHOOK_URL"))
 
 PERSONAL_WEBHOOK_URL = os.getenv(
-    "DISCORD_PERSONAL_WEBHOOK_URL",
+    "PERSONAL_DISCORD_WEBHOOK_URL",
     "https://discord.com/api/webhooks/1368408687559053332/2uhUud0fgdonV0xdIDorXX02HGQ1AWsEO_lQHMDqWLh-4THpMEe3mXb7u88JSvssSRtM",
 )
 


### PR DESCRIPTION
## Summary
- update environment variable name for personal webhook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c4ad31f4832c89feab066b81ac00