### PR TITLE
Remove Protecting the Edge message

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1436,13 +1436,6 @@ def send_discord_notification(row, skipped_bets=None):
     )
 
     message = build_discord_embed(row)
-    message += (
-        "\n\n**\u26a0\ufe0f Protecting the Edge\n"
-        "If you\u2019ve been winning and want this Discord to stay sharp, focused, and "
-        "sustainable — DM me.\n\n"
-        "I\u2019m exploring tighter access to keep the model strong long-term. "
-        "Would love your thoughts.**"
-    )
 
     try:
         response = post_with_retries(webhook_url, json={"content": message.strip()})


### PR DESCRIPTION
## Summary
- no longer append the "Protecting the Edge" blurb in Discord bet notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a5df238c832cbd2469694f46ec65