### PR TITLE
Scale required_market_move by contributing books

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -122,7 +122,10 @@ def recheck_pending_bets(path: str = PENDING_BETS_PATH) -> None:
             movement = float(new_prob) - float(prev_prob)
         except Exception:
             movement = 0.0
-        if movement < required_market_move(hours_to_game):
+
+        books = bet.get("per_book")
+        book_count = len(books) if isinstance(books, dict) and books else 1
+        if movement < required_market_move(hours_to_game, book_count=book_count):
             updated[key] = bet
             continue
         row = bet.copy()

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -294,10 +294,12 @@ def should_log_bet(
         except Exception:
             movement = 0.0
 
-        threshold = required_market_move(hours_to_game)
+        books = new_bet.get("per_book")
+        book_count = len(books) if isinstance(books, dict) and books else 1
+        threshold = required_market_move(hours_to_game, book_count=book_count)
         if movement < threshold:
             _log_verbose(
-                f"⛔ should_log_bet: Early bet suppressed — movement {movement:.3f} < {threshold:.3f}",
+                f"⛔ should_log_bet: Early bet suppressed — movement {movement:.3f} < {threshold:.3f} (books={book_count})",
                 verbose,
             )
             try:


### PR DESCRIPTION
## Summary
- scale `required_market_move` threshold by number of contributing books
- pass book count when checking early bets
- keep the threshold table based on 7 books
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b814f8c8832ca7134ae75cd08259