### PR TITLE
Lower market move threshold

### DIFF
--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -39,7 +39,7 @@ def required_market_move(hours_to_game: float, book_count: int = 1) -> float:
 
     Notes
     -----
-    A base movement unit of ``0.006`` (approximate 20-cent move at one book)
+    A base movement unit of ``0.0045`` (approximate 15-cent move at one book)
     is scaled by two multipliers:
 
     1. ``time_multiplier``
@@ -51,7 +51,9 @@ def required_market_move(hours_to_game: float, book_count: int = 1) -> float:
         increases by ``0.25`` for each missing book (capped at ``2.5`` when only
         one book is available).
     """
-    movement_unit = 0.006
+    BASE_MOVEMENT_UNIT = 0.0045
+
+    movement_unit = BASE_MOVEMENT_UNIT
 
     hours = 0.0 if hours_to_game is None else float(hours_to_game)
     clamped_time = min(max(hours, 0.0), 24.0)
@@ -109,7 +111,7 @@ def print_threshold_table() -> None:
     for hours in key_hours:
         threshold = required_market_move(hours, book_count=7)
         percent = threshold * 100.0
-        units = threshold / 0.006
+        units = threshold / 0.0045
         print(f"{hours:>3}h | {percent:>6.3f}% | {units:>5.2f}")
 
 

--- a/tests/test_confirmation_utils.py
+++ b/tests/test_confirmation_utils.py
@@ -12,20 +12,20 @@ from core.confirmation_utils import (
 
 
 def test_required_market_move_endpoints():
-    assert required_market_move(0, book_count=7) == pytest.approx(0.006)
-    assert required_market_move(24, book_count=7) == pytest.approx(0.018)
+    assert required_market_move(0, book_count=7) == pytest.approx(0.0045)
+    assert required_market_move(24, book_count=7) == pytest.approx(0.0135)
     # Hours beyond 24h should cap at 24h threshold
-    assert required_market_move(36, book_count=7) == pytest.approx(0.018)
+    assert required_market_move(36, book_count=7) == pytest.approx(0.0135)
 
 
 def test_required_market_move_midpoint():
-    expected = (1.0 + 2.0 * 12 / 24.0) * 0.006
+    expected = (1.0 + 2.0 * 12 / 24.0) * 0.0045
     assert required_market_move(12, book_count=7) == pytest.approx(expected)
 
 
 def test_required_market_move_book_scaling():
     hours = 10
-    expected = 0.006 * (1.0 + 2.0 * hours / 24.0) * (1.0 + (4 * 0.25))
+    expected = 0.0045 * (1.0 + 2.0 * hours / 24.0) * (1.0 + (4 * 0.25))
     assert required_market_move(hours, book_count=3) == pytest.approx(expected)
     assert required_market_move(hours, book_count=7) < expected
 
@@ -34,7 +34,7 @@ def test_confirmation_strength_example():
     hours = 12
     required = required_market_move(hours, book_count=7)
     strength = confirmation_strength(0.009, hours)
-    assert required == pytest.approx(0.012)
+    assert required == pytest.approx(0.009)
     expected = 0.009 / required_market_move(hours)
     assert strength == pytest.approx(expected)
 
@@ -57,7 +57,7 @@ def test_print_threshold_table_output(capsys):
     for idx, hours in enumerate(key_hours, start=1):
         threshold = required_market_move(hours, book_count=7)
         percent = threshold * 100.0
-        units = threshold / 0.006
+        units = threshold / 0.0045
         expected = f"{hours:>3}h | {percent:>6.3f}% | {units:>5.2f}".strip()
         assert out_lines[idx] == expected
 


### PR DESCRIPTION
## Summary
- reduce BASE_MOVEMENT_UNIT in `required_market_move` to 0.0045
- adjust threshold output table
- update unit tests for the new sensitivity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bf4973c8832c8657fdc2c8c5307f