### PR TITLE
Improve top‑up checks

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -181,6 +181,50 @@ def _compute_csv_theme_total(
     return total
 
 
+def get_best_logged_theme_odds_ev(
+    csv_path: str, game_id: str, theme_key: str, segment: str
+) -> tuple[float, float]:
+    """Return the max EV% and best decimal odds previously logged for a theme."""
+    best_ev = float("-inf")
+    best_odds = float("-inf")
+    if not os.path.exists(csv_path):
+        return best_ev, best_odds
+
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row.get("game_id") != game_id:
+                    continue
+                mkt = row.get("market", "")
+                base = mkt.replace("alternate_", "")
+                seg = get_segment_group(mkt)
+                theme = get_theme({"side": row.get("side", ""), "market": base})
+                key = get_theme_key(base, theme)
+                if key != theme_key or seg != segment:
+                    continue
+                ev_val = row.get("ev_percent")
+                odds_val = row.get("market_odds")
+                try:
+                    if ev_val is not None and ev_val != "":
+                        ev_f = float(ev_val)
+                        if ev_f > best_ev:
+                            best_ev = ev_f
+                except Exception:
+                    pass
+                try:
+                    if odds_val is not None and odds_val != "":
+                        dec = decimal_odds(float(odds_val))
+                        if dec > best_odds:
+                            best_odds = dec
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    return best_ev, best_odds
+
+
 def should_log_bet(
     new_bet: dict,
     existing_theme_stakes: dict,
@@ -190,6 +234,7 @@ def should_log_bet(
     eval_tracker: dict | None = None,
     reference_tracker: dict | None = None,
     existing_csv_stakes: dict | None = None,
+    csv_path: str = os.path.join("logs", "market_evals.csv"),
 ) -> dict:
     """Evaluate whether a bet should be logged and return a structured result.
 
@@ -416,6 +461,32 @@ def should_log_bet(
     delta_raw = stake - delta_base
     delta = round(delta_raw, 2)
     if delta >= MIN_TOPUP_STAKE:
+        # Check best logged odds/EV for this theme
+        best_ev, best_odds = get_best_logged_theme_odds_ev(
+            csv_path, game_id, theme_key, segment
+        )
+        curr_odds_val = None
+        try:
+            curr_odds_val = float(new_bet.get("market_odds"))
+        except Exception:
+            pass
+        curr_dec_odds = decimal_odds(curr_odds_val) if curr_odds_val is not None else None
+        ev_val = None
+        try:
+            ev_val = float(ev)
+        except Exception:
+            pass
+        if (
+            ev_val is not None
+            and curr_dec_odds is not None
+            and ev_val < best_ev
+            and curr_dec_odds < best_odds
+        ):
+            new_bet["entry_type"] = "none"
+            new_bet["skip_reason"] = "odds_or_ev_worsened"
+            _log_verbose("⛔ Skipping top-up: odds_or_ev_worsened", verbose)
+            return build_skipped_evaluation("odds_or_ev_worsened", game_id, new_bet)
+
         new_bet["stake"] = delta
         new_bet["entry_type"] = "top-up"
         _log_verbose(

--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import csv
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.should_log_bet import should_log_bet, get_theme, get_theme_key, get_segment_group
@@ -381,3 +382,105 @@ def test_theme_exposure_kept_when_csv_matches():
     )
     assert result["skip"] is True
     assert existing_theme_stakes[exposure_key] == 1.2
+
+
+def test_top_up_rejected_if_theme_worse_than_csv(tmp_path):
+    csv_path = tmp_path / "market_evals.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "game_id",
+                "market",
+                "side",
+                "ev_percent",
+                "market_odds",
+                "stake",
+                "entry_type",
+                "segment",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "game_id": "gid",
+                "market": "h2h",
+                "side": "TeamA",
+                "ev_percent": 8.0,
+                "market_odds": 120,
+                "stake": 1.0,
+                "entry_type": "first",
+                "segment": "full_game",
+            }
+        )
+
+    bet = {
+        "game_id": "gid",
+        "market": "h2h",
+        "side": "TeamA",
+        "full_stake": 2.0,
+        "ev_percent": 7.0,
+        "market_odds": 115,
+    }
+    exposure_key = _exposure_key(bet)
+    existing_theme_stakes = {exposure_key: 1.0}
+
+    result = should_log_bet(
+        bet,
+        existing_theme_stakes,
+        verbose=False,
+        csv_path=str(csv_path),
+    )
+    assert result["skip"] is True
+    assert result["reason"] == "odds_or_ev_worsened"
+
+
+def test_top_up_allowed_if_one_metric_improves(tmp_path):
+    csv_path = tmp_path / "market_evals.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "game_id",
+                "market",
+                "side",
+                "ev_percent",
+                "market_odds",
+                "stake",
+                "entry_type",
+                "segment",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "game_id": "gid",
+                "market": "h2h",
+                "side": "TeamA",
+                "ev_percent": 6.0,
+                "market_odds": 110,
+                "stake": 1.0,
+                "entry_type": "first",
+                "segment": "full_game",
+            }
+        )
+
+    bet = {
+        "game_id": "gid",
+        "market": "h2h",
+        "side": "TeamA",
+        "full_stake": 2.0,
+        "ev_percent": 5.5,
+        "market_odds": 115,
+    }
+    exposure_key = _exposure_key(bet)
+    existing_theme_stakes = {exposure_key: 1.0}
+
+    result = should_log_bet(
+        bet,
+        existing_theme_stakes,
+        verbose=False,
+        csv_path=str(csv_path),
+    )
+    assert result["log"] is True
+    assert result["entry_type"] == "top-up"


### PR DESCRIPTION
## Summary
- block top‑ups if odds and EV worsen vs best logged theme bet
- store helper to read highest EV and odds from `market_evals.csv`
- expose log path parameter on `should_log_bet`
- test new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562093664c832cbdc6e892d7f0f7ff