### PR TITLE
Remove odds deterioration check for top-ups

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -406,37 +406,6 @@ def should_log_bet(
                 "suppressed_low_agreement", game_id, new_bet
             )
 
-    # 🚦 Reject bet if odds worsened versus reference snapshot
-    if prior_entry is not None and theme_total > 0:
-        try:
-            prev_odds = prior_entry.get("market_odds")
-            curr_odds = new_bet.get("market_odds")
-            prev_ev = prior_entry.get("ev_percent")
-            curr_ev = new_bet.get("ev_percent")
-            odds_worsened = False
-            reason_parts = []
-            if prev_ev is not None and curr_ev is not None:
-                if float(curr_ev) < float(prev_ev):
-                    reason_parts.append(
-                        f"EV fell from {float(prev_ev):.1f}% to {float(curr_ev):.1f}%"
-                    )
-                    odds_worsened = True
-            if prev_odds is not None and curr_odds is not None:
-                if decimal_odds(float(curr_odds)) < decimal_odds(float(prev_odds)):
-                    reason_parts.append(
-                        f"odds worsened from {int(prev_odds):+d} to {int(curr_odds):+d}"
-                    )
-                    odds_worsened = True
-            if odds_worsened:
-                msg = "⛔ Skipping top-up: " + ", ".join(reason_parts)
-                _log_verbose(msg, verbose)
-                new_bet["entry_type"] = "none"
-                new_bet["skip_reason"] = SkipReason.ODDS_WORSENED.value
-                return build_skipped_evaluation(
-                    SkipReason.ODDS_WORSENED.value, game_id, new_bet
-                )
-        except Exception:
-            pass
 
     tracker_key = f"{game_id}:{market}:{side}"
 

--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -130,7 +130,7 @@ def test_first_bet_logged_even_if_odds_worse():
     assert result["entry_type"] == "first"
 
 
-def test_top_up_rejected_if_odds_worse():
+def test_top_up_logged_even_if_odds_worse():
     bet = {
         "game_id": "gid",
         "market": "h2h",
@@ -145,9 +145,9 @@ def test_top_up_rejected_if_odds_worse():
     reference = {tracker_key: {"market_odds": 110, "ev_percent": 7.0}}
 
     result = should_log_bet(bet, existing_theme_stakes, verbose=False, reference_tracker=reference)
-    assert result["skip"] is True
-    assert bet["entry_type"] == "none"
-    assert result["reason"] == SkipReason.ODDS_WORSENED.value
+    assert result["log"] is True
+    assert result["entry_type"] == "top-up"
+    assert result["stake"] == pytest.approx(1.0)
 
 
 def test_first_bet_logged_if_odds_improve():


### PR DESCRIPTION
## Summary
- remove odds worsening logic from `should_log_bet`
- update tests to expect top-ups even when odds have worsened

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856615b8cdc832cb33cd75542589a3e